### PR TITLE
Difference between definition and implementation of getStatisticsOfMission()

### DIFF
--- a/map-structure/vi-map/include/vi-map/vi-map.h
+++ b/map-structure/vi-map/include/vi-map/vi-map.h
@@ -498,7 +498,7 @@ class VIMap : public backend::ResourceMap,
       std::vector<size_t>* num_unknown_landmarks_per_camera,
       std::vector<size_t>* total_num_landmarks_per_camera,
       size_t* num_landmarks, size_t* num_vertices, size_t* num_observations,
-      double* duration_s, time_t* start_time, time_t* end_time) const;
+      double* duration_s, int64_t* start_time, int64_t* end_time) const;
 
   std::string printMapStatistics(
       const vi_map::MissionId& mission, const unsigned int mission_number,


### PR DESCRIPTION
While trying to use this project on a 32bit architecture, I spot a difference between the prototype of `getStatisticsOfMission()` and its implementation: `start_time` and `end_time` does't have the same type. This make the 32bit build fail because `time_t` and `int64_t` doesn't have the same size in this architecture.

```
#map-structure/vi-map/include/vi-map/vi-map.h:494
  void getStatisticsOfMission(
      const vi_map::MissionId& mission_id,
      std::vector<size_t>* num_good_landmarks_per_camera,
      std::vector<size_t>* num_bad_landmarks_per_camera,
      std::vector<size_t>* num_unknown_landmarks_per_camera,
      std::vector<size_t>* total_num_landmarks_per_camera,
      size_t* num_landmarks, size_t* num_vertices, size_t* num_observations,
double* duration_s, time_t* start_time, time_t* end_time) const;
```

```
#map-structure/vi-map/src/vi-map.cc:317
void VIMap::getStatisticsOfMission(
    const vi_map::MissionId& mission_id,
    std::vector<size_t>* num_good_landmarks_per_camera,
    std::vector<size_t>* num_bad_landmarks_per_camera,
    std::vector<size_t>* num_unknown_landmarks_per_camera,
    std::vector<size_t>* total_num_landmarks_per_camera, size_t* num_landmarks,
    size_t* num_vertices, size_t* num_observations, double* duration_s,
int64_t* start_time_ns, int64_t* end_time_ns) const {
```

I choosed to keep only `int64_t` because every usage of this function are using this type and a nanosecond timestamp doesn't fit in 32bit.