### PR TITLE
Fix two keyframing issues

### DIFF
--- a/algorithms/map-sparsification/src/keyframe-pruning.cc
+++ b/algorithms/map-sparsification/src/keyframe-pruning.cc
@@ -251,7 +251,9 @@ size_t selectKeyframesBasedOnHeuristics(
   }
 
   // The last vertex is always a keyframe
-  insert_keyframe(current_vertex_id);
+  if (last_keyframe_id != current_vertex_id) {
+    insert_keyframe(current_vertex_id);
+  }
 
   return selected_keyframes->size();
 }

--- a/algorithms/map-sparsification/src/keyframe-pruning.cc
+++ b/algorithms/map-sparsification/src/keyframe-pruning.cc
@@ -250,7 +250,9 @@ size_t selectKeyframesBasedOnHeuristics(
     ++num_frames_since_last_keyframe;
   }
 
-  // The last vertex is always a keyframe
+
+  // Ensure the last vertex is added as a keyframe if it hasn't been selected
+  // by any heuristics yet.
   if (last_keyframe_id != current_vertex_id) {
     insert_keyframe(current_vertex_id);
   }

--- a/console-plugins/map-sparsification-plugin/src/keyframe-pruning.cc
+++ b/console-plugins/map-sparsification-plugin/src/keyframe-pruning.cc
@@ -37,9 +37,6 @@ int keyframeMapBasedOnHeuristics(
     return common::CommandStatus::kUnknownError;
   }
 
-  if (keyframe_ids.back() != last_vertex_id) {
-    keyframe_ids.emplace_back(last_vertex_id);
-  }
 
   // Optionally, visualize the selected keyframes.
   if (plotter != nullptr) {

--- a/map-structure/vi-map/src/pose-graph.cc
+++ b/map-structure/vi-map/src/pose-graph.cc
@@ -92,7 +92,7 @@ void PoseGraph::mergeNeighboringEdges<TransformationEdge>(
   CHECK_EQ(merge_into_vertex_id, edge_between_vertices.from());
   CHECK_EQ(edge_between_vertices.to(), edge_after_next_vertex.from());
 
-  const aslam::SensorId& sensor_id = edge_between_vertices.getSensorId();
+  const aslam::SensorId sensor_id = edge_between_vertices.getSensorId();
   CHECK_EQ(sensor_id, edge_after_next_vertex.getSensorId());
 
   const Edge::EdgeType edge_type = edge_between_vertices.getType();


### PR DESCRIPTION
Deals with two issues related to kfh:  

1. Solves crash during kfh when a vertex is deleted during merging and a const ref pointing to the transformation_edge's sensor_id no longer exists and contains a bogus value. This triggers a CHECK_EQ down the line. (by chance possibly only occurring in Ubuntu 16.04)

  2. Solves crash where the last vertex in a map is erroneously added twice during keyframing, causing issues downstream.