### PR TITLE
Add save_map service call to maplab_node.

### DIFF
--- a/applications/maplab-node/src/maplab-ros-node.cc
+++ b/applications/maplab-node/src/maplab-ros-node.cc
@@ -150,6 +150,11 @@ MaplabRosNode::MaplabRosNode(
   } else {
     LOG(INFO) << "[MaplabROSNode] No lidar localization map provided.";
   }
+
+  boost::function<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)>
+      save_map_callback =
+          boost::bind(&MaplabRosNode::saveMapCallback, this, _1, _2);
+  save_map_srv_ = nh_.advertiseService("save_map", save_map_callback);
 }
 
 bool MaplabRosNode::run() {


### PR DESCRIPTION
Add the save_map service call to maplab_node, which currently is only available in maplab_server_node. This is useful in cases where we are working with large maps and saving on exit where the saving does not finish before ROS escalates to SIGTERM (hard-coded to 15s, PR pending for ROS melodic). 