### PR TITLE
Fix checkMapConsistency crash when resources are present but unmerged

### DIFF
--- a/console-plugins/vi-map-visualization-plugin/src/visualization-plugin.cc
+++ b/console-plugins/vi-map-visualization-plugin/src/visualization-plugin.cc
@@ -106,7 +106,7 @@ VisualizationPlugin::VisualizationPlugin(common::Console* console)
         return visualizeReprojectedDepthResource(
             backend::ResourceType::kPointCloudXYZI);
       },
-      "Publish all xyz + intesity point clouds.", common::Processing::Sync);
+      "Publish all xyz + intensity point clouds.", common::Processing::Sync);
 
   addCommand(
       {"visualize_xyzrgbn_pointclouds"},

--- a/map-structure/vi-map/src/vi-map.cc
+++ b/map-structure/vi-map/src/vi-map.cc
@@ -38,6 +38,7 @@ VIMap::~VIMap() {}
 void VIMap::deepCopy(const VIMap& other) {
   clear();
   CHECK(mergeAllMissionsFromMapWithoutResources(other));
+  CHECK(checkMapConsistency(other));
   ResourceMap::deepCopy(other);
 }
 
@@ -145,7 +146,6 @@ bool VIMap::mergeAllMissionsFromMapWithoutResources(
         landmark_id, original_landmark_store_vertex_id);
   }
 
-  CHECK(checkMapConsistency(*this));
   return true;
 }
 
@@ -157,6 +157,8 @@ bool VIMap::mergeAllMissionsFromMap(const vi_map::VIMap& other) {
 
   VLOG(1) << "Copying metadata and resource infos.";
   ResourceMap::mergeFromMap(other);
+
+  CHECK(checkMapConsistency(*this));
   return true;
 }
 

--- a/map-structure/vi-map/src/vi-map.cc
+++ b/map-structure/vi-map/src/vi-map.cc
@@ -38,8 +38,8 @@ VIMap::~VIMap() {}
 void VIMap::deepCopy(const VIMap& other) {
   clear();
   CHECK(mergeAllMissionsFromMapWithoutResources(other));
-  CHECK(checkMapConsistency(other));
   ResourceMap::deepCopy(other);
+  CHECK(checkMapConsistency(other));
 }
 
 bool VIMap::mergeAllMissionsFromMapWithoutResources(


### PR DESCRIPTION
Move checkMapConsistency outside of mergeAllMissionsFromMapWithoutResources s.t. the former doesn't fail when resources haven't been merged yet but everything else has. This change means that checkMapConsistency must be called after ResourceMap::mergeFromMap if resources are present.