### PR TITLE
Outlier removal for absolute pose constraints

### DIFF
--- a/algorithms/dense-reconstruction/depth_integration/include/depth-integration/depth-integration.h
+++ b/algorithms/dense-reconstruction/depth_integration/include/depth-integration/depth-integration.h
@@ -9,6 +9,8 @@
 
 DECLARE_bool(dense_depth_integrator_enable_sigint_breaker);
 
+DECLARE_bool(dense_depth_integrator_visualize_only_with_known_baseframe);
+
 namespace depth_integration {
 
 // NOTE: This interface is currently still depending on voxblox, but only for

--- a/algorithms/dense-reconstruction/depth_integration/src/depth-integration.cc
+++ b/algorithms/dense-reconstruction/depth_integration/src/depth-integration.cc
@@ -26,6 +26,11 @@ DEFINE_bool(
     "closest in time to a vertex.");
 
 DEFINE_bool(
+    dense_depth_integrator_visualize_only_with_known_baseframe, false,
+    "If enabled, the depth integrator is only integrating missions that have a "
+    "known baseframe.");
+
+DEFINE_bool(
     dense_depth_integrator_enable_sigint_breaker, true,
     "If enabled, the depth integrator can be interrupted with Ctrl-C. Should "
     "be disabled if depth integration is used in a headless console mode, such "
@@ -188,6 +193,15 @@ void integrateAllFrameDepthResourcesOfType(
   // Start integration.
   for (const vi_map::MissionId& mission_id : mission_ids) {
     const vi_map::VIMission& mission = vi_map.getMission(mission_id);
+
+    // If this flags is set, we skip this mission if its baseframe is not known.
+    if (FLAGS_dense_depth_integrator_visualize_only_with_known_baseframe) {
+      const vi_map::MissionBaseFrameId& mission_baseframe_id =
+          mission.getBaseFrameId();
+      if (!vi_map.getMissionBaseFrame(mission_baseframe_id).is_T_G_M_known()) {
+        continue;
+      }
+    }
 
     if (!mission.hasNCamera()) {
       VLOG(1) << "Mission " << mission_id
@@ -373,6 +387,15 @@ void integrateAllOptionalSensorDepthResourcesOfType(
   for (const vi_map::MissionId& mission_id : mission_ids) {
     VLOG(1) << "Integrating mission " << mission_id;
     const vi_map::VIMission& mission = vi_map.getMission(mission_id);
+
+    // If this flags is set, we skip this mission if its baseframe is not known.
+    if (FLAGS_dense_depth_integrator_visualize_only_with_known_baseframe) {
+      const vi_map::MissionBaseFrameId& mission_baseframe_id =
+          mission.getBaseFrameId();
+      if (!vi_map.getMissionBaseFrame(mission_baseframe_id).is_T_G_M_known()) {
+        continue;
+      }
+    }
 
     const aslam::Transformation& T_G_M =
         vi_map.getMissionBaseFrameForMission(mission_id).get_T_G_M();

--- a/algorithms/dense-reconstruction/depth_integration/src/depth-map-integration.cc
+++ b/algorithms/dense-reconstruction/depth_integration/src/depth-map-integration.cc
@@ -58,6 +58,15 @@ void integrateAllFrameDepthMapResourcesOfType(
   for (const vi_map::MissionId& mission_id : mission_ids) {
     const vi_map::VIMission& mission = vi_map.getMission(mission_id);
 
+    // If this flags is set, we skip this mission if its baseframe is not known.
+    if (FLAGS_dense_depth_integrator_visualize_only_with_known_baseframe) {
+      const vi_map::MissionBaseFrameId& mission_baseframe_id =
+          mission.getBaseFrameId();
+      if (!vi_map.getMissionBaseFrame(mission_baseframe_id).is_T_G_M_known()) {
+        continue;
+      }
+    }
+
     if (!mission.hasNCamera()) {
       VLOG(1) << "Mission " << mission_id
               << " has no NCamera, hence no such resources!";

--- a/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
+++ b/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
@@ -22,7 +22,10 @@ struct ProbeResult {
   bool wasSuccessful() const;
 };
 
-void removeOutliersInAbsolutePoseConstraints(vi_map::VIMap* map);
+void setMissionBaseframeToKnownIfHasAbs6DoFConstraints(
+    vi_map::VIMap* map);
+
+void removeOutliersInAbsolute6DoFConstraints(vi_map::VIMap* map);
 
 void setMissionBaseframeKnownState(
     const vi_map::MissionId& mission_id, const bool baseframe_known_state,

--- a/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
+++ b/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
@@ -22,6 +22,8 @@ struct ProbeResult {
   bool wasSuccessful() const;
 };
 
+void removeOutliersInAbsolutePoseConstraints(vi_map::VIMap* map);
+
 void setMissionBaseframeKnownState(
     const vi_map::MissionId& mission_id, const bool baseframe_known_state,
     vi_map::VIMap* map);

--- a/algorithms/map-anchoring/src/map-anchoring.cc
+++ b/algorithms/map-anchoring/src/map-anchoring.cc
@@ -8,6 +8,25 @@ DEFINE_bool(
     add_anchored_missions_to_database, true,
     "Add missions that got anchored to the loop detector database too.");
 
+DEFINE_double(
+    abs_constraints_baseframe_min_number_of_constraints, 5,
+    "Minimum number of constraints to allow for baseframe alignment or "
+    "consistency checking.");
+
+DEFINE_double(
+    abs_constraints_baseframe_min_inlier_ratio, 0.2,
+    "Minimum inlier ratio for successful mission to absolute reference "
+    "alignment.");
+DEFINE_double(
+    abs_constraints_baseframe_ransac_max_orientation_error_rad, 0.174,
+    "Maximum orientation error for inliers for mission baseframe RANSAC.");
+DEFINE_double(
+    abs_constraints_baseframe_ransac_max_position_error_m, 2.0,
+    "Maximum position error for inliers for mission baseframe RANSAC.");
+DEFINE_int32(
+    abs_constraints_baseframe_ransac_num_interations, 2000,
+    "Maximum number of iterations for mission baseframe RANSAC.");
+
 namespace map_anchoring {
 
 void setMissionBaseframeKnownState(
@@ -58,23 +77,37 @@ bool anchorAllMissions(
   std::unordered_map<vi_map::MissionId, int> remaining_trials_for_mission_map;
   vi_map::MissionIdList all_missions;
   map->getAllMissionIds(&all_missions);
+  std::stringstream ss;
+  ss << "\n";
+  ss << "----------------------------------------------------------------\n";
+  ss << "                         MapAnchoring                           \n";
+  ss << "----------------------------------------------------------------\n";
+  ss << " Current State:\n";
   for (const vi_map::MissionId& mission_id : all_missions) {
     const vi_map::Mission& mission = map->getMission(mission_id);
     const vi_map::MissionBaseFrame& base_frame =
         map->getMissionBaseFrame(mission.getBaseFrameId());
-    if (!base_frame.is_T_G_M_known()) {
+    const bool baseframe_is_known = base_frame.is_T_G_M_known();
+    if (!baseframe_is_known) {
       missions_to_anchor.push(mission_id);
       remaining_trials_for_mission_map[mission_id] = kTrialsPerMission;
     }
+    ss << "\t- " << mission_id << ":\t"
+       << ((baseframe_is_known) ? "anchored\n" : "not anchored\n");
   }
-
+  ss << "----------------------------------------------------------------\n";
+  ss << " Result:\n";
   if (missions_to_anchor.size() == all_missions.size()) {
-    LOG(ERROR) << "At least one mission needs to have a known baseframe.";
+    ss << "\tFailed: At least one mission needs to have a known baseframe. \n";
+    ss << "----------------------------------------------------------------\n";
+    LOG(INFO) << ss.str();
     return false;
   }
 
   if (missions_to_anchor.empty()) {
-    LOG(INFO) << "All baseframes are known -- nothing to do.";
+    ss << "\tAll baseframes are known -- nothing to do.\n";
+    ss << "----------------------------------------------------------------\n";
+    LOG(INFO) << ss.str();
     return true;
   }
 
@@ -149,16 +182,19 @@ bool anchorAllMissions(
   CHECK(missions_to_anchor.empty());
 
   if (!abandoned_missions.empty()) {
-    LOG(WARNING) << "Could not anchor all missions. Still have the following "
-                 << "unanchored:";
+    ss << "\tCould not anchor all missions, still unknown:\n";
     for (const vi_map::MissionId& abandoned_mission_id : abandoned_missions) {
-      LOG(WARNING) << "\t" << abandoned_mission_id;
+      ss << "\t- " << abandoned_mission_id << "\n";
     }
     map->resetMissionSelection();
+    ss << "----------------------------------------------------------------\n";
+    LOG(INFO) << ss.str();
     return false;
   }
   map->resetMissionSelection();
-  VLOG(3) << "All missions anchored.";
+  ss << "\tAll missions anchored.\n";
+  ss << "----------------------------------------------------------------\n";
+  LOG(INFO) << ss.str();
   return true;
 }
 
@@ -253,6 +289,135 @@ void probeMissionAnchoring(
       &result->num_vertex_candidate_links,
       &result->average_landmark_match_inlier_ratio, map, &result->T_G_M,
       &inlier_constraints);
+}
+
+void removeOutliersInAbsolutePoseConstraints(vi_map::VIMap* map) {
+  CHECK_NOTNULL(map);
+
+  LOG(INFO) << "Removing outliers from absolute pose constraints";
+
+  std::stringstream ss;
+  ss << "\n";
+  ss << "----------------------------------------------------------------\n";
+  ss << "           Absolute Pose Constraints  - Outlier Removal         \n";
+  ss << "----------------------------------------------------------------\n";
+
+  vi_map::MissionIdList missions_to_optimize;
+  map->getAllMissionIds(&missions_to_optimize);
+  for (const vi_map::MissionId& mission_id : missions_to_optimize) {
+    const vi_map::VIMission& mission = map->getMission(mission_id);
+    if (!mission.hasAbsolute6DoFSensor()) {
+      continue;
+    }
+
+    // Get vertices.
+    pose_graph::VertexIdList vertices;
+    map->getAllVertexIdsInMissionAlongGraph(mission_id, &vertices);
+
+    // Get absolute pose sensor.
+    const aslam::SensorId& sensor_id = mission.getAbsolute6DoFSensor();
+    const aslam::Transformation T_S_B =
+        map->getSensorManager().getSensor_T_B_S(sensor_id).inverse();
+
+    aslam::TransformationVector T_G_M_vector;
+    std::vector<std::pair<pose_graph::VertexId, uint32_t>>
+        vertex_id_and_abs_constraint_idx;
+
+    for (const pose_graph::VertexId& vertex_id : vertices) {
+      const vi_map::Vertex& vertex = map->getVertex(vertex_id);
+      const std::vector<vi_map::Absolute6DoFMeasurement>&
+          abs_6dof_measurements = vertex.getAbsolute6DoFMeasurements();
+      const aslam::Transformation& T_B_M = vertex.get_T_M_I().inverse();
+
+      uint32_t abs_constraint_idx = 0u;
+      for (const vi_map::Absolute6DoFMeasurement& abs_6dof_measurement :
+           abs_6dof_measurements) {
+        const aslam::Transformation& T_G_S = abs_6dof_measurement.get_T_G_S();
+        const aslam::Transformation T_G_M = T_G_S * T_S_B * T_B_M;
+
+        T_G_M_vector.push_back(T_G_M);
+        vertex_id_and_abs_constraint_idx.emplace_back(
+            vertex_id, abs_constraint_idx);
+
+        ++abs_constraint_idx;
+      }
+    }
+
+    const uint32_t num_abs_constraints = T_G_M_vector.size();
+    ss << "\t- " << mission_id << " has " << num_abs_constraints
+       << "absolute pose constraints\n";
+
+    // Check flags.
+    CHECK_GE(FLAGS_abs_constraints_baseframe_min_number_of_constraints, 3);
+    CHECK_GE(FLAGS_abs_constraints_baseframe_min_inlier_ratio, 0.0);
+    CHECK_GE(FLAGS_abs_constraints_baseframe_ransac_num_interations, 0);
+    CHECK_GE(
+        FLAGS_abs_constraints_baseframe_ransac_max_orientation_error_rad, 0.0);
+    CHECK_GE(FLAGS_abs_constraints_baseframe_ransac_max_position_error_m, 0.0);
+
+    if (num_abs_constraints <
+        FLAGS_abs_constraints_baseframe_min_number_of_constraints) {
+      ss << "\t  "
+         << "-> Failed: not enough constraints (< "
+         << FLAGS_abs_constraints_baseframe_min_number_of_constraints << ")\n";
+      ss << "----------------------------------------------------------------"
+            "\n";
+      continue;
+    }
+
+    // RANSAC and LSQ estimate of the mission baseframe transformation.
+    const int kNumInliersThreshold =
+        num_abs_constraints * FLAGS_abs_constraints_baseframe_min_inlier_ratio;
+    aslam::Transformation T_G_M_LS;
+    int num_inliers = 0;
+    std::random_device device;
+    const int ransac_seed = device();
+    std::unordered_set<int> inlier_indices;
+
+    common::transformationRansac(
+        T_G_M_vector, FLAGS_abs_constraints_baseframe_ransac_num_interations,
+        FLAGS_abs_constraints_baseframe_ransac_max_orientation_error_rad,
+        FLAGS_abs_constraints_baseframe_ransac_max_position_error_m,
+        ransac_seed, &T_G_M_LS, &num_inliers, &inlier_indices);
+
+    ss << "\t  -> Inliers " << num_inliers << "/" << num_abs_constraints
+       << "\n";
+    if (num_inliers < kNumInliersThreshold) {
+      ss << "\t  -> Failed: Not enough inliers (" << kNumInliersThreshold
+         << "<)\n";
+      ss << "----------------------------------------------------------------"
+            "\n";
+
+      continue;
+    }
+
+    // Remove outliers.
+    CHECK_EQ(vertex_id_and_abs_constraint_idx.size(), num_abs_constraints);
+    for (uint32_t global_idx = 0u; global_idx < num_abs_constraints;
+         ++global_idx) {
+      if (inlier_indices.count(global_idx) > 0u) {
+        continue;
+      }
+      const std::pair<pose_graph::VertexId, uint32_t>
+          vertex_id_with_constraint_idx =
+              vertex_id_and_abs_constraint_idx[global_idx];
+      const pose_graph::VertexId vertex_id =
+          vertex_id_with_constraint_idx.first;
+      const uint32_t constraint_idx = vertex_id_with_constraint_idx.second;
+
+      vi_map::Vertex& vertex = map->getVertex(vertex_id);
+      std::vector<vi_map::Absolute6DoFMeasurement>& abs_6dof_measurements =
+          vertex.getAbsolute6DoFMeasurements();
+
+      abs_6dof_measurements.erase(
+          abs_6dof_measurements.begin() + constraint_idx);
+    }
+    const uint32_t num_outliers = num_abs_constraints - num_inliers;
+    ss << "\t  -> Outliers " << num_outliers << "/" << num_abs_constraints
+       << " -> REMOVED\n";
+    ss << "----------------------------------------------------------------\n";
+  }
+  LOG(INFO) << ss.str();
 }
 
 }  // namespace map_anchoring

--- a/algorithms/map-anchoring/src/map-anchoring.cc
+++ b/algorithms/map-anchoring/src/map-anchoring.cc
@@ -29,6 +29,24 @@ DEFINE_int32(
 
 namespace map_anchoring {
 
+void setMissionBaseframeToKnownIfHasAbs6DoFConstraints(vi_map::VIMap* map) {
+  CHECK_NOTNULL(map);
+
+  vi_map::MissionIdList mission_ids;
+  map->getAllMissionIds(&mission_ids);
+
+  for (const vi_map::MissionId& mission_id : mission_ids) {
+    const bool has_absolute_6dof_constraints =
+        map->getNumAbsolute6DoFMeasurementsInMission(mission_id) > 0u;
+
+    if (has_absolute_6dof_constraints) {
+      const vi_map::MissionBaseFrameId& mission_baseframe_id =
+          map->getMission(mission_id).getBaseFrameId();
+      map->getMissionBaseFrame(mission_baseframe_id).set_is_T_G_M_known(true);
+    }
+  }
+}
+
 void setMissionBaseframeKnownState(
     const vi_map::MissionId& mission_id, const bool baseframe_known_state,
     vi_map::VIMap* map) {
@@ -291,7 +309,7 @@ void probeMissionAnchoring(
       &inlier_constraints);
 }
 
-void removeOutliersInAbsolutePoseConstraints(vi_map::VIMap* map) {
+void removeOutliersInAbsolute6DoFConstraints(vi_map::VIMap* map) {
   CHECK_NOTNULL(map);
 
   LOG(INFO) << "Removing outliers from absolute pose constraints";

--- a/algorithms/map-anchoring/src/map-anchoring.cc
+++ b/algorithms/map-anchoring/src/map-anchoring.cc
@@ -363,7 +363,7 @@ void removeOutliersInAbsolute6DoFConstraints(vi_map::VIMap* map) {
 
     const uint32_t num_abs_constraints = T_G_M_vector.size();
     ss << "\t- " << mission_id << " has " << num_abs_constraints
-       << "absolute pose constraints\n";
+       << " absolute pose constraints\n";
 
     // Check flags.
     CHECK_GE(FLAGS_abs_constraints_baseframe_min_number_of_constraints, 3);

--- a/algorithms/map-anchoring/src/map-anchoring.cc
+++ b/algorithms/map-anchoring/src/map-anchoring.cc
@@ -9,19 +9,19 @@ DEFINE_bool(
     "Add missions that got anchored to the loop detector database too.");
 
 DEFINE_double(
-    abs_constraints_baseframe_min_number_of_constraints, 5,
+    abs_constraints_baseframe_min_number_of_constraints, 3,
     "Minimum number of constraints to allow for baseframe alignment or "
     "consistency checking.");
 
 DEFINE_double(
-    abs_constraints_baseframe_min_inlier_ratio, 0.2,
+    abs_constraints_baseframe_min_inlier_ratio, 0.5,
     "Minimum inlier ratio for successful mission to absolute reference "
     "alignment.");
 DEFINE_double(
-    abs_constraints_baseframe_ransac_max_orientation_error_rad, 0.174,
+    abs_constraints_baseframe_ransac_max_orientation_error_rad, 0.0872,
     "Maximum orientation error for inliers for mission baseframe RANSAC.");
 DEFINE_double(
-    abs_constraints_baseframe_ransac_max_position_error_m, 2.0,
+    abs_constraints_baseframe_ransac_max_position_error_m, 0.5,
     "Maximum position error for inliers for mission baseframe RANSAC.");
 DEFINE_int32(
     abs_constraints_baseframe_ransac_num_interations, 2000,

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -892,11 +892,9 @@ void MaplabServerNode::runSubmapProcessingCommands(
         options, missions_to_optimize, &outlier_rejection_options, map.get());
 
     if (FLAGS_maplab_server_remove_outliers_in_absolute_pose_constraints) {
-      {
-        std::lock_guard<std::mutex> command_lock(submap_commands_mutex_);
-        submap_commands_[submap_process.map_hash] =
-            "remove_abs_constraint_outlier";
-      }
+      std::lock_guard<std::mutex> command_lock(submap_commands_mutex_);
+      submap_commands_[submap_process.map_hash] =
+          "remove_abs_constraint_outlier";
       map_anchoring::removeOutliersInAbsolutePoseConstraints(map.get());
     }
 

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -4,6 +4,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <landmark-triangulation/pose-interpolator.h>
+#include <map-anchoring/map-anchoring.h>
 #include <map-optimization/outlier-rejection-solver.h>
 #include <map-optimization/solver-options.h>
 #include <map-optimization/vi-map-optimizer.h>
@@ -14,12 +15,14 @@
 #include <signal.h>
 #include <vi-map-basic-plugin/vi-map-basic-plugin.h>
 #include <vi-map-helpers/vi-map-landmark-quality-evaluation.h>
+#include <vi-map/landmark-quality-metrics.h>
 
 #include <atomic>
 #include <memory>
 #include <string>
 
 DECLARE_bool(ros_free);
+DECLARE_uint64(vi_map_landmark_quality_min_observers);
 
 DEFINE_int32(
     maplab_server_submap_loading_thread_pool_size, 4,
@@ -45,6 +48,11 @@ DEFINE_bool(
     "If enabled, the submap processing commands are ignored and a default set "
     "of commands is executed on the submaps. These commands are landmark "
     "quality evaluation and optimization.");
+
+DEFINE_bool(
+    maplab_server_remove_outliers_in_absolute_pose_constraints, true,
+    "If enabled, the submap processing will after optimization run "
+    "RANSAC LSQ on the absolute pose constraints to remove outliers.");
 
 namespace maplab {
 MaplabServerNode::MaplabServerNode(const MaplabServerNodeConfig& config)
@@ -862,6 +870,12 @@ void MaplabServerNode::runSubmapProcessingCommands(
       std::lock_guard<std::mutex> command_lock(submap_commands_mutex_);
       submap_commands_[submap_process.map_hash] = "elq";
     }
+    if (FLAGS_vi_map_landmark_quality_min_observers > 2) {
+      LOG(WARNING) << "[[MaplabServerNode] Minimum required landmark observers "
+                   << "is set to "
+                   << FLAGS_vi_map_landmark_quality_min_observers
+                   << ",  this might be too stricht if keyframing is enabled.";
+    }
     vi_map_helpers::evaluateLandmarkQuality(
         missions_to_optimize_list, map.get());
 
@@ -876,6 +890,16 @@ void MaplabServerNode::runSubmapProcessingCommands(
         nullptr /*no plotter*/, false /*signal handler enabled*/);
     optimizer.optimize(
         options, missions_to_optimize, &outlier_rejection_options, map.get());
+
+    if (FLAGS_maplab_server_remove_outliers_in_absolute_pose_constraints) {
+      {
+        std::lock_guard<std::mutex> command_lock(submap_commands_mutex_);
+        submap_commands_[submap_process.map_hash] =
+            "remove_abs_constraint_outlier";
+      }
+      map_anchoring::removeOutliersInAbsolutePoseConstraints(map.get());
+    }
+
   } else {
     // Copy console to process the global map.
     const std::string console_name =

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -649,18 +649,6 @@ bool MaplabServerNode::appendAvailableSubmaps() {
                  "used to initalize merged map with key '"
               << kMergedMapKey << "'.";
       map_manager_.renameMap(submap_process.map_key, kMergedMapKey);
-
-      // Set baseframe of this first mission to known.
-      vi_map::VIMapManager::MapWriteAccess map =
-          map_manager_.getMapWriteAccess(kMergedMapKey);
-      CHECK_EQ(map->numMissions(), 1u);
-      const vi_map::MissionId mission_id = map->getIdOfFirstMission();
-      CHECK(mission_id.isValid());
-      const vi_map::MissionBaseFrameId& mission_baseframe_id =
-          map->getMission(mission_id).getBaseFrameId();
-      CHECK(mission_baseframe_id.isValid());
-      map->getMissionBaseFrame(mission_baseframe_id).set_is_T_G_M_known(true);
-
       found_new_submaps = true;
     } else {
       LOG(INFO) << "[MaplabServerNode] MapMerging - merge submap '"
@@ -895,7 +883,7 @@ void MaplabServerNode::runSubmapProcessingCommands(
       std::lock_guard<std::mutex> command_lock(submap_commands_mutex_);
       submap_commands_[submap_process.map_hash] =
           "remove_abs_constraint_outlier";
-      map_anchoring::removeOutliersInAbsolutePoseConstraints(map.get());
+      map_anchoring::removeOutliersInAbsolute6DoFConstraints(map.get());
     }
 
   } else {

--- a/common/maplab-common/include/maplab-common/geometry-inl.h
+++ b/common/maplab-common/include/maplab-common/geometry-inl.h
@@ -111,12 +111,13 @@ LeftQuaternionJPLMultiplicationMatrix(const Eigen::MatrixBase<Derived>& q) {
 
 template <template <typename, typename> class Container>
 void transformationRansac(
-    const Container<pose::Transformation,
-                    Eigen::aligned_allocator<pose::Transformation>>&
+    const Container<
+        pose::Transformation, Eigen::aligned_allocator<pose::Transformation>>&
         T_A_B_samples,
     int num_iterations, double threshold_orientation_radians,
     double threshold_position_meters, int ransac_seed,
-    pose::Transformation* T_A_B, int* num_inliers) {
+    pose::Transformation* T_A_B, int* num_inliers,
+    std::unordered_set<int>* inlier_indices) {
   CHECK_NOTNULL(T_A_B);
   CHECK_NOTNULL(num_inliers);
   CHECK(!T_A_B_samples.empty());
@@ -173,6 +174,11 @@ void transformationRansac(
   T_A_B->getRotation().toImplementation().coeffs() = q_A_B_JPL;
   T_A_B->getPosition() = p_A_B_inliers / best_inlier_indices.size();
   *num_inliers = best_inlier_indices.size();
+
+  if (inlier_indices != nullptr) {
+    inlier_indices->insert(
+        best_inlier_indices.begin(), best_inlier_indices.end());
+  }
 }
 
 namespace geometry {

--- a/common/maplab-common/include/maplab-common/geometry.h
+++ b/common/maplab-common/include/maplab-common/geometry.h
@@ -1,6 +1,7 @@
 #ifndef MAPLAB_COMMON_GEOMETRY_H_
 #define MAPLAB_COMMON_GEOMETRY_H_
 #include <random>
+#include <unordered_set>
 
 #include <Eigen/Core>
 #include <aslam/common/memory.h>
@@ -57,12 +58,13 @@ Eigen::Matrix<double, 4, 1> ComputeLSAverageQuaternionJPL(
 
 template <template <typename, typename> class Container>
 void transformationRansac(
-    const Container<pose::Transformation,
-                    Eigen::aligned_allocator<pose::Transformation>>&
+    const Container<
+        pose::Transformation, Eigen::aligned_allocator<pose::Transformation>>&
         T_A_B_samples,
     int num_iterations, double threshold_orientation_radians,
     double threshold_position_meters, int ransac_seed,
-    pose::Transformation* T_A_B, int* num_inliers);
+    pose::Transformation* T_A_B, int* num_inliers,
+    std::unordered_set<int>* inlier_indices = nullptr);
 
 double getMaxDisparityRadAngleOfUnitVectorBundle(
     const Aligned<std::vector, Eigen::Vector3d>& unit_incidence_rays);

--- a/console-plugins/map-anchoring-plugin/src/anchoring-plugin.cc
+++ b/console-plugins/map-anchoring-plugin/src/anchoring-plugin.cc
@@ -136,6 +136,9 @@ int AnchoringPlugin::anchorAllMissions() const {
   vi_map::VIMapManager map_manager;
   vi_map::VIMapManager::MapWriteAccess map =
       map_manager.getMapWriteAccess(selected_map_key);
+
+  map_anchoring::setMissionBaseframeToKnownIfHasAbs6DoFConstraints(map.get());
+
   const bool success = map_anchoring::anchorAllMissions(map.get());
   if (hasPlotter()) {
     getPlotter().visualizeMap(*map);

--- a/map-structure/vi-map/src/sensor-manager.cc
+++ b/map-structure/vi-map/src/sensor-manager.cc
@@ -142,7 +142,6 @@ bool SensorManager::getBaseSensorIdIfUnique(aslam::SensorId* sensor_id) const {
     return false;
   }
 
-  bool is_unique = true;
   aslam::SensorId unique_base_id;
   for (auto sensor_id_to_base_id : base_sensor_id_map_) {
     if (!unique_base_id.isValid()) {


### PR DESCRIPTION
Adds consistency check function to detect and remove outliers in absolute pose constraints by applying RANSAC LSQ on the base frame resulting from each constraint, i.e. it tries to find a rigid alignment (= map anchoring) of the map based on the constraints and removes all outliers. The idea is to run this on the submaps in the maplab server, which are small enough to not have accumulated significant drift, hence a rigid alignment should be possible.