### PR TITLE
Add delete mission service calls to mapping server

### DIFF
--- a/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
+++ b/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
@@ -8,6 +8,8 @@
 #include <diagnostic_msgs/KeyValue.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <maplab_msgs/BatchMapLookup.h>
+#include <maplab_msgs/DeleteAllRobotMissions.h>
+#include <maplab_msgs/DeleteMission.h>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
 #include <std_srvs/Empty.h>
@@ -44,6 +46,14 @@ class MaplabServerRosNode {
       maplab_msgs::BatchMapLookup::Request& requests,     // NOLINT
       maplab_msgs::BatchMapLookup::Response& responses);  // NOLINT
 
+  bool deleteMissionCallback(
+      maplab_msgs::DeleteMission::Request& request,     // NOLINT
+      maplab_msgs::DeleteMission::Response& response);  // NOLINT
+
+  bool deleteAllRobotMissionsCallback(
+      maplab_msgs::DeleteAllRobotMissions::Request& request,     // NOLINT
+      maplab_msgs::DeleteAllRobotMissions::Response& response);  // NOLINT
+
   bool publishPoseCorrection(
       const int64_t timestamp_ns, const std::string& robot_name,
       const aslam::Transformation& T_G_curr_B_curr,
@@ -60,6 +70,8 @@ class MaplabServerRosNode {
 
   ros::ServiceServer save_map_srv_;
   ros::ServiceServer map_lookup_srv_;
+  ros::ServiceServer delete_mission_srv_;
+  ros::ServiceServer delete_all_robot_missions_srv_;
 
   // State for running for maplab.
   ros::AsyncSpinner maplab_spinner_;

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -1173,13 +1173,13 @@ bool MaplabServerNode::deleteBlacklistedMissions() {
         blacklisted_missions_copy;
     {
       std::lock_guard<std::mutex> lock(blacklisted_missions_mutex_);
+      if (blacklisted_missions_.empty()) {
+        // Nothing todo here.
+        return true;
+      }
       blacklisted_missions_copy = blacklisted_missions_;
     }
 
-    if (blacklisted_missions_copy.empty()) {
-      // Nothing todo here.
-      return true;
-    }
 
     // Actually delete the mission from the merge map, if present.
 
@@ -1222,13 +1222,11 @@ bool MaplabServerNode::deleteBlacklistedMissions() {
         // Check robot to robot mission info.
         RobotMissionInformation& robot_mission_info =
             robot_to_mission_id_map_[robot_name];
-        auto it = std::find(
+        auto it = std::remove(
             robot_mission_info.mission_ids.begin(),
             robot_mission_info.mission_ids.end(), blacklisted_mission_id);
-        const bool has_mission = it != robot_mission_info.mission_ids.end();
-        if (has_mission) {
-          robot_mission_info.mission_ids.erase(it);
-        }
+        robot_mission_info.mission_ids.erase(it,
+            robot_mission_info.mission_ids.end());
 
         // If this was the only/last mission of that robot, remove the entry and
         // also publish an empty point cloud to the dense map topic.

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -1199,7 +1199,7 @@ bool MaplabServerNode::deleteBlacklistedMissions() {
       merged_map->removeMission(mission_id, true /*remove baseframe*/);
     }
 
-    // Cleanup bookkeeping (robot to mission, mission to robot)
+    // Cleanup bookeeping (robot to mission, mission to robot).
     {
       std::lock_guard<std::mutex> lock(robot_to_mission_id_map_mutex_);
 
@@ -1210,7 +1210,7 @@ bool MaplabServerNode::deleteBlacklistedMissions() {
         const std::string& robot_name =
             blacklisted_mission_id_and_robot_name.second;
 
-        // CHeck mission to robot map.
+        // Check mission to robot map.
         if (mission_id_to_robot_map_.count(blacklisted_mission_id) > 0u) {
           // Copy intended, to avoid invaliding the refrence when deleting the
           // element.

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -675,7 +675,15 @@ bool MaplabServerNode::appendAvailableSubmaps() {
     // Check if submap is blacklisted and delete it.
     CHECK(!submap_process.map_key.empty());
     CHECK(map_manager_.hasMap(submap_process.map_key));
-    if (isSubmapBlacklisted(const std::string& map_key)) {
+    if (isSubmapBlacklisted(submap_process.map_key)) {
+      vi_map::MissionId submap_mission_id;
+      {
+        vi_map::VIMapManager::MapReadAccess submap =
+            map_manager_.getMapReadAccess(submap_process.map_key);
+        CHECK_EQ(submap->numMissions(), 1u);
+        submap_mission_id = submap->getIdOfFirstMission();
+      }
+
       LOG(WARNING) << "[MaplabServerNode] MapMerging - Received a new submap "
                    << "of deleted mission " << submap_mission_id
                    << ", will discard it.";
@@ -1187,6 +1195,9 @@ bool MaplabServerNode::deleteBlacklistedMissions() {
            blacklisted_missions_copy) {
         const vi_map::MissionId& blacklisted_mission_id =
             blacklisted_mission_id_and_robot_name.first;
+        const std::string& robot_name =
+            blacklisted_mission_id_and_robot_name.second;
+
         // CHeck mission to robot map.
         if (mission_id_to_robot_map_.count(blacklisted_mission_id) > 0u) {
           // Copy intended, to avoid invaliding the refrence when deleting the

--- a/applications/maplab-server-node/src/maplab-server-ros-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-ros-node.cc
@@ -67,6 +67,22 @@ MaplabServerRosNode::MaplabServerRosNode(
           boost::bind(&MaplabServerRosNode::mapLookupCallback, this, _1, _2);
   map_lookup_srv_ = nh_.advertiseService("map_lookup", map_lookup_callback);
 
+  boost::function<bool(
+      maplab_msgs::DeleteMission::Request&,
+      maplab_msgs::DeleteMission::Response&)>
+      delete_mission_callback = boost::bind(
+          &MaplabServerRosNode::deleteMissionCallback, this, _1, _2);
+  delete_mission_srv_ =
+      nh_.advertiseService("delete_mission", delete_mission_callback);
+
+  boost::function<bool(
+      maplab_msgs::DeleteAllRobotMissions::Request&,
+      maplab_msgs::DeleteAllRobotMissions::Response&)>
+      delete_all_robot_missions_callback = boost::bind(
+          &MaplabServerRosNode::deleteAllRobotMissionsCallback, this, _1, _2);
+  delete_all_robot_missions_srv_ = nh_.advertiseService(
+      "delete_all_robot_missions", delete_all_robot_missions_callback);
+
   boost::function<void(const diagnostic_msgs::KeyValueConstPtr&)>
       submap_loading_callback =
           boost::bind(&MaplabServerRosNode::submapLoadingCallback, this, _1);
@@ -242,6 +258,30 @@ bool MaplabServerRosNode::mapLookupCallback(
 
     responses.map_lookups.emplace_back(std::move(response));
   }
+
+  return true;
+}
+
+bool MaplabServerRosNode::deleteMissionCallback(
+    maplab_msgs::DeleteMission::Request& request,      // NOLINT
+    maplab_msgs::DeleteMission::Response& response) {  // NOLINT
+  const std::string& partial_mission_id_string =
+      request.mission_id_to_delete.data;
+
+  response.success.data = maplab_server_node_->deleteMission(
+      partial_mission_id_string, &response.message.data);
+
+  return true;
+}
+
+bool MaplabServerRosNode::deleteAllRobotMissionsCallback(
+    maplab_msgs::DeleteAllRobotMissions::Request& request,      // NOLINT
+    maplab_msgs::DeleteAllRobotMissions::Response& response) {  // NOLINT
+
+  const std::string& robot_name = request.robot_name.data;
+
+  response.success.data = maplab_server_node_->deleteAllRobotMissions(
+      robot_name, &response.message.data);
 
   return true;
 }


### PR DESCRIPTION
Adds two service calls, one to delete one mission using a (partial) mission id has (>= 4) and another to delete all missions of a specific robot.