### PR TITLE
add max time in seconds flag for BA

### DIFF
--- a/algorithms/map-optimization/include/map-optimization/solver-options.h
+++ b/algorithms/map-optimization/include/map-optimization/solver-options.h
@@ -8,6 +8,7 @@
 #include <maplab-common/threading-helpers.h>
 
 DECLARE_int32(ba_num_iterations);
+DECLARE_int32(ba_max_time_seconds);
 DECLARE_bool(ba_enable_signal_handler);
 DECLARE_bool(ba_use_cgnr_linear_solver);
 DECLARE_bool(ba_use_jacobi_scaling);
@@ -18,6 +19,7 @@ inline ceres::Solver::Options initSolverOptionsFromFlags() {
   ceres::Solver::Options options;
   options.minimizer_progress_to_stdout = true;
   options.max_num_iterations = FLAGS_ba_num_iterations;
+  options.max_solver_time_in_seconds = FLAGS_ba_max_time_seconds;
   options.function_tolerance = 1e-12;
   options.gradient_tolerance = 1e-10;
   options.parameter_tolerance = 1e-8;

--- a/algorithms/map-optimization/src/outlier-rejection-solver.cc
+++ b/algorithms/map-optimization/src/outlier-rejection-solver.cc
@@ -159,6 +159,8 @@ ceres::TerminationType solveStep(
   ceres::Solver::Summary summary;
   ceres::Solve(local_options, &problem, &summary);
 
+  LOG(INFO) << summary.FullReport();
+
   return summary.termination_type;
 }
 

--- a/algorithms/map-optimization/src/outlier-rejection-solver.cc
+++ b/algorithms/map-optimization/src/outlier-rejection-solver.cc
@@ -241,14 +241,16 @@ ceres::TerminationType solveWithOutlierRejection(
   ceres::TerminationType termination_type =
       ceres::TerminationType::NO_CONVERGENCE;
   int num_iters_remaining = solver_options.max_num_iterations;
-  while (num_iters_remaining > 0) {
+  timing::TimerImpl timer_full_ba("BA: Full", true);
+  double max_solver_time_s = solver_options.max_solver_time_in_seconds;
+  while (num_iters_remaining > 0 && max_solver_time_s > 0) {
+    timer_full_ba.Start();
     const int step_iters = std::min(
         num_iters_remaining, rejection_options.reject_outliers_every_n_iters);
 
     timing::Timer timer_solve("BA: Solve");
     termination_type =
         solveStep(solver_options, step_iters, optimization_problem, &callback);
-    timer_solve.Stop();
 
     timing::Timer timer_copy("BA: CopyDataToMap");
     optimization_problem->getOptimizationStateBufferMutable()
@@ -263,6 +265,7 @@ ceres::TerminationType solveWithOutlierRejection(
       break;
     }
 
+    max_solver_time_s -= timer_full_ba.Stop();
     num_iters_remaining -= step_iters;
   }
 

--- a/algorithms/map-optimization/src/solver-options.cc
+++ b/algorithms/map-optimization/src/solver-options.cc
@@ -1,6 +1,8 @@
 #include "map-optimization/solver-options.h"
 
 DEFINE_int32(ba_num_iterations, 30, "Max. number of iterations.");
+DEFINE_int32(ba_max_time_seconds, 1e6, 
+    "Maximum amount of time for which the solver should run.");
 DEFINE_bool(
     ba_enable_signal_handler, true,
     "If enabled, the optimization will register a signal handler that allows "


### PR DESCRIPTION
## General
This PR solely enables the functionality to constrain the optimization time of ceres. 

## Changelog
 * Adds a flag to set the maximum time in seconds for an optimization. 