### PR TITLE
Fixed outliers in absolute constraints

### DIFF
--- a/map-structure/sensors/include/sensors/absolute-6dof-pose.h
+++ b/map-structure/sensors/include/sensors/absolute-6dof-pose.h
@@ -96,10 +96,15 @@ class Absolute6DoFMeasurement : public Measurement {
   Absolute6DoFMeasurement() {
     T_G_S_.setIdentity();
     T_G_S_covariance_.setZero();
+    has_T_M_B_cached_ = false;
   }
 
   explicit Absolute6DoFMeasurement(const aslam::SensorId& sensor_id)
-      : Measurement(sensor_id) {}
+      : Measurement(sensor_id) {
+    T_G_S_.setIdentity();
+    T_G_S_covariance_.setZero();
+    has_T_M_B_cached_ = false;
+  }
 
   explicit Absolute6DoFMeasurement(
       const aslam::SensorId& sensor_id, const int64_t timestamp_nanoseconds,
@@ -107,7 +112,9 @@ class Absolute6DoFMeasurement : public Measurement {
       const aslam::TransformationCovariance& covariance)
       : Measurement(sensor_id, timestamp_nanoseconds),
         T_G_S_(T_G_S),
-        T_G_S_covariance_(covariance) {}
+        T_G_S_covariance_(covariance) {
+    has_T_M_B_cached_ = false;
+  }
 
   inline const aslam::Transformation& get_T_G_S() const {
     return T_G_S_;


### PR DESCRIPTION
Tiny fix of uninitialize variable. Basically this caused that sometimes, based on the random initialization of the `has_T_M_B_cached_` variable, the cached pose would be used even when it didn't exists. So in cases where the constraints were not well in sync this could cause massive outliers as instead of a transformation close to the vertex pose it was identity.

@mfehr maybe this might fix some issues in the april tag constraints you had