### PR TITLE
Remove private apriltags repo from the dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,9 +91,6 @@
 [submodule "dependencies/internal/linter"]
 	path = dependencies/internal/linter
 	url = git@github.com:ethz-asl/linter.git
-[submodule "dependencies/3rdparty/arl_apriltags2_ros"]
-	path = dependencies/3rdparty/arl_apriltags2_ros
-	url = git@github.com:ethz-asl/arl_apriltags2_ros.git
 [submodule "dependencies/internal/maplab_tools"]
 	path = dependencies/internal/maplab_tools
 	url = git@github.com:ethz-asl/maplab_tools.git


### PR DESCRIPTION
## General

This Pr removes the dependency of ARL's apriltags repo which is anyway private.

## Changelog
 * Removed apriltags submodule