### PR TITLE
Temporal Buffer Bugfix & other small changes from dense mapping push

### DIFF
--- a/backend/map-resources/include/map-resources/resource-common.h
+++ b/backend/map-resources/include/map-resources/resource-common.h
@@ -194,6 +194,14 @@ class IntensityVisitor : public boost::static_visitor<float> {
   std::size_t index_;
 };
 
+// Converts a CSV string with resource type numbers into a vector of
+// ResourceTypes. If the string is empty it returns true and an empty vector. If
+// one of the CSV entries is not a valid ResourceType, it returns false and an
+// empty vector.
+bool csvStringToResourceTypeList(
+    const std::string& csv_resource_types,
+    std::vector<ResourceType>* resource_type_list);
+
 }  // namespace backend
 
 #endif  // MAP_RESOURCES_RESOURCE_COMMON_H_

--- a/backend/map-resources/src/resource-common.cc
+++ b/backend/map-resources/src/resource-common.cc
@@ -70,4 +70,48 @@ bool isSameResource(
   return true;
 }
 
+bool csvStringToResourceTypeList(
+    const std::string& csv_resource_types,
+    std::vector<ResourceType>* resource_type_list) {
+  CHECK_NOTNULL(resource_type_list)->clear();
+  if (csv_resource_types.empty()) {
+    return true;
+  }
+
+  static const std::string kDelimiter = ",";
+
+  std::vector<std::string> resource_type_strings;
+  common::tokenizeString(
+      csv_resource_types, kDelimiter, &resource_type_strings);
+
+  if (resource_type_strings.empty()) {
+    // Nothing to do here.
+    return true;
+  }
+
+  for (const std::string& resource_type_string : resource_type_strings) {
+    bool is_valid = false;
+    try {
+      const int resource_type_int = std::stoi(resource_type_string);
+      if (resource_type_int >= 0 &&
+          resource_type_int < static_cast<int>(ResourceType::kCount)) {
+        is_valid = true;
+        resource_type_list->emplace_back(
+            static_cast<ResourceType>(resource_type_int));
+      }
+    } catch (std::invalid_argument const& e) {
+      // Fall through intended.
+    } catch (std::out_of_range const& e) {
+      // Fall through intended.
+    }
+    if (!is_valid) {
+      LOG(ERROR) << "'" << resource_type_string
+                 << "' is not a valid resource type number!";
+      resource_type_list->clear();
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace backend

--- a/common/maplab-common/test/test_temporal_buffer.cc
+++ b/common/maplab-common/test/test_temporal_buffer.cc
@@ -89,7 +89,7 @@ TEST_F(TemporalBufferFixture, GetNearestValueToTimeWorks) {
 }
 
 TEST_F(TemporalBufferFixture, GetNearestValueToTimeMaxDeltaWorks) {
-  addValue(TestData(30));
+  addValue(TestData(40));
   addValue(TestData(10));
   addValue(TestData(20));
 
@@ -107,13 +107,13 @@ TEST_F(TemporalBufferFixture, GetNearestValueToTimeMaxDeltaWorks) {
   EXPECT_TRUE(buffer_.getNearestValueToTime(16, kMaxDelta, &retrieved_item));
   EXPECT_EQ(retrieved_item.timestamp, 20);
 
-  EXPECT_TRUE(buffer_.getNearestValueToTime(26, kMaxDelta, &retrieved_item));
-  EXPECT_EQ(retrieved_item.timestamp, 30);
+  EXPECT_TRUE(buffer_.getNearestValueToTime(36, kMaxDelta, &retrieved_item));
+  EXPECT_EQ(retrieved_item.timestamp, 40);
 
-  EXPECT_TRUE(buffer_.getNearestValueToTime(32, kMaxDelta, &retrieved_item));
-  EXPECT_EQ(retrieved_item.timestamp, 30);
+  EXPECT_TRUE(buffer_.getNearestValueToTime(42, kMaxDelta, &retrieved_item));
+  EXPECT_EQ(retrieved_item.timestamp, 40);
 
-  EXPECT_FALSE(buffer_.getNearestValueToTime(36, kMaxDelta, &retrieved_item));
+  EXPECT_FALSE(buffer_.getNearestValueToTime(46, kMaxDelta, &retrieved_item));
 
   buffer_.clear();
   addValue(TestData(10));
@@ -133,6 +133,8 @@ TEST_F(TemporalBufferFixture, GetNearestValueToTimeMaxDeltaWorks) {
 
   buffer_.clear();
   addValue(TestData(10));
+
+  EXPECT_FALSE(buffer_.getNearestValueToTime(1, kMaxDelta, &retrieved_item));
 
   EXPECT_TRUE(buffer_.getNearestValueToTime(6, kMaxDelta, &retrieved_item));
   EXPECT_EQ(retrieved_item.timestamp, 10);

--- a/visualization/src/common-rviz-visualization.cc
+++ b/visualization/src/common-rviz-visualization.cc
@@ -68,9 +68,7 @@ void createEmptySphereListMarker(
   sphere_marker->scale.y = scale;
   sphere_marker->scale.z = scale;
 
-  sphere_marker->pose.position.x = 0.0;
-  sphere_marker->pose.position.y = 0.0;
-  sphere_marker->pose.position.z = 0.0;
+  visualization::setPoseToIdentity(sphere_marker);
 
   sphere_marker->color.a = alpha;
   sphere_marker->header.frame_id = frame;
@@ -831,7 +829,6 @@ void publishSpheres(
   }
 
   const double scale = spheres[0].radius;
-
   visualization_msgs::Marker marker;
   createEmptySphereListMarker(
       marker_id, frame, name_space, scale, alpha, &marker);

--- a/visualization/src/viwls-graph-plotter.cc
+++ b/visualization/src/viwls-graph-plotter.cc
@@ -8,9 +8,9 @@
 #include <sensors/sensor-types.h>
 #include <tf/tf.h>
 #include <tf/transform_broadcaster.h>
-#include <visualization_msgs/MarkerArray.h>
 #include <vi-map/vertex.h>
 #include <vi-map/viwls-edge.h>
+#include <visualization_msgs/MarkerArray.h>
 
 #include <algorithm>
 #include <functional>
@@ -189,6 +189,7 @@ void ViwlsGraphRvizPlotter::publishEdges(
     const std::string& topic_extension, const bool wait_for_subscriber) const {
   visualization::LineSegmentVector line_segments;
   visualization::LineSegmentVector lc_transformation_line_segments;
+  visualization::SphereVector lc_vertices;
   visualization::ArrowVector wheel_odom_transformation_arrows;
 
   visualization::Palette palette =
@@ -261,6 +262,22 @@ void ViwlsGraphRvizPlotter::publishEdges(
       lc_transformation_line_segments.push_back(lc_line_segment);
       line_segment.color = local_color;
 
+      visualization::Sphere lc_sphere_from, lc_sphere_to;
+      lc_sphere_from.position = to_T_G_I.getPosition();
+      lc_sphere_from.color.red = 0u;
+      lc_sphere_from.color.green = 255u;
+      lc_sphere_from.color.blue = 0u;
+      lc_sphere_from.radius = 0.3;
+      lc_sphere_from.alpha = 0.6;
+      lc_vertices.emplace_back(lc_sphere_from);
+      lc_sphere_to.position = to_T_G_I_lc.getPosition();
+      lc_sphere_to.color.red = 255u;
+      lc_sphere_to.color.green = 0u;
+      lc_sphere_to.color.blue = 0u;
+      lc_sphere_to.radius = 0.3;
+      lc_sphere_to.alpha = 0.6;
+      lc_vertices.emplace_back(lc_sphere_to);
+
       // Assemble the transformation and covariance for later visualization.
       lc_edges_T_G_B.emplace_back(to_T_G_I);
       lc_edges_B_cov.emplace_back(edge.get_T_A_B_Covariance());
@@ -330,14 +347,21 @@ void ViwlsGraphRvizPlotter::publishEdges(
         FLAGS_vis_default_namespace, kEdgeTopic + "/wheel_odometry_arrows");
   }
 
-  if (!lc_edges_T_G_B.empty() && FLAGS_vis_lc_edge_covariances) {
+  if (!lc_edges_T_G_B.empty() && !lc_vertices.empty() &&
+      FLAGS_vis_lc_edge_covariances) {
     CHECK_EQ(lc_edges_T_G_B.size(), lc_edges_B_cov.size());
     const visualization::Color covariance_color = visualization::kCommonYellow;
     const std::string kEdgeCovTopic = kEdgeTopic + "/loop_closure_covariances";
-    const std::string kNamespace = "loop_closure_covariances";
+    const std::string kEdgeCovNamespace = "loop_closure_covariances";
     visualization::publishPoseCovariances(
         lc_edges_T_G_B, lc_edges_B_cov, covariance_color, FLAGS_tf_map_frame,
-        kNamespace, kEdgeCovTopic);
+        kEdgeCovNamespace, kEdgeCovTopic);
+
+    const std::string kEdgeVertexTopic = kEdgeTopic + "/loop_closure_vertices";
+    const std::string kEdgeVertexNamespace = "loop_closure_vertices";
+    visualization::publishSpheres(
+        lc_vertices, marker_id, FLAGS_tf_map_frame, kEdgeVertexNamespace,
+        kEdgeVertexTopic);
   }
 }
 

--- a/visualization/src/viwls-graph-plotter.cc
+++ b/visualization/src/viwls-graph-plotter.cc
@@ -265,17 +265,17 @@ void ViwlsGraphRvizPlotter::publishEdges(
       visualization::Sphere lc_sphere_from, lc_sphere_to;
       lc_sphere_from.position = to_T_G_I.getPosition();
       lc_sphere_from.color.red = 0u;
-      lc_sphere_from.color.green = 255u;
-      lc_sphere_from.color.blue = 0u;
+      lc_sphere_from.color.green = 0u;
+      lc_sphere_from.color.blue = 255u;
       lc_sphere_from.radius = 0.3;
-      lc_sphere_from.alpha = 0.6;
+      lc_sphere_from.alpha = 0.8;
       lc_vertices.emplace_back(lc_sphere_from);
       lc_sphere_to.position = to_T_G_I_lc.getPosition();
       lc_sphere_to.color.red = 255u;
       lc_sphere_to.color.green = 0u;
       lc_sphere_to.color.blue = 0u;
       lc_sphere_to.radius = 0.3;
-      lc_sphere_to.alpha = 0.6;
+      lc_sphere_to.alpha = 0.8;
       lc_vertices.emplace_back(lc_sphere_to);
 
       // Assemble the transformation and covariance for later visualization.

--- a/visualization/src/viwls-graph-plotter.cc
+++ b/visualization/src/viwls-graph-plotter.cc
@@ -263,19 +263,19 @@ void ViwlsGraphRvizPlotter::publishEdges(
       line_segment.color = local_color;
 
       visualization::Sphere lc_sphere_from, lc_sphere_to;
-      lc_sphere_from.position = to_T_G_I.getPosition();
+      lc_sphere_from.position = from_T_G_I.getPosition();
       lc_sphere_from.color.red = 0u;
-      lc_sphere_from.color.green = 0u;
+      lc_sphere_from.color.green = 255u;
       lc_sphere_from.color.blue = 255u;
       lc_sphere_from.radius = 0.3;
-      lc_sphere_from.alpha = 0.8;
+      lc_sphere_from.alpha = 0.3;
       lc_vertices.emplace_back(lc_sphere_from);
-      lc_sphere_to.position = to_T_G_I_lc.getPosition();
+      lc_sphere_to.position = to_T_G_I.getPosition();
       lc_sphere_to.color.red = 255u;
       lc_sphere_to.color.green = 0u;
-      lc_sphere_to.color.blue = 0u;
+      lc_sphere_to.color.blue = 255u;
       lc_sphere_to.radius = 0.3;
-      lc_sphere_to.alpha = 0.8;
+      lc_sphere_to.alpha = 0.3;
       lc_vertices.emplace_back(lc_sphere_to);
 
       // Assemble the transformation and covariance for later visualization.


### PR DESCRIPTION
Changes:
 - Fixes a bug in the temporal buffer nearest value lookup. There was a corner case near the lower border of the buffer that resulted in an invalid timestamp being returned. The function has been fixed, improved and the unit tests extended.
 - Bugfix in RVIZ visualization of sphere markers, the orientation was not set, RVIZ complained.
 - Adds (optional) sphere markers for loop closure edges to highlight the vertices it connects.
 - Adds convenience function to read a list of resource type from a CSV string of the type numbers.