### PR TITLE
Refactor optimization parameter handling, add option to retrieve iteration/solver summaries.

### DIFF
--- a/algorithms/localization-evaluator/src/mission-aligner.cc
+++ b/algorithms/localization-evaluator/src/mission-aligner.cc
@@ -109,12 +109,14 @@ void alignAndCooptimizeMissionsWithoutLandmarkMerge(
   VLOG(1) << "Anchor succeeded.";
 
   VLOG(1) << "Optimizing missions.";
-  ceres::Solver::Options solver_options =
-      map_optimization::initSolverOptionsFromFlags();
+
   map_optimization::ViProblemOptions vi_problem_options =
       map_optimization::ViProblemOptions::initFromGFlags();
 
-  solver_options.max_num_iterations = 10;
+  vi_problem_options.enable_visual_outlier_rejection = false;
+
+  vi_problem_options.solver_options.max_num_iterations = 10;
+
   if (optimize_only_query_mission) {
     vi_problem_options.fix_vertices = true;
     vi_problem_options.fix_landmark_positions = true;
@@ -127,8 +129,8 @@ void alignAndCooptimizeMissionsWithoutLandmarkMerge(
   // Optimize all missions in the map
   vi_map::MissionIdSet all_mission_ids;
   map->getAllMissionIds(&all_mission_ids);
-  const bool success = optimizer.optimize(
-      vi_problem_options, solver_options, all_mission_ids, nullptr, map);
+  const bool success =
+      optimizer.optimize(vi_problem_options, all_mission_ids, map);
   CHECK(success) << "Optimization failed!";
 
   for (const vi_map::VertexKeyPointToStructureMatch& revert_item :

--- a/algorithms/map-optimization/include/map-optimization/optimization-problem.h
+++ b/algorithms/map-optimization/include/map-optimization/optimization-problem.h
@@ -102,6 +102,13 @@ class OptimizationProblem {
   LocalParameterizations local_parameterizations_;
 };
 
+// Struct to hold the summaries and the final state of solver variables of the
+// optimization.
+struct OptimizationProblemResult {
+  std::vector<ceres::IterationSummary> iteration_summaries;
+  std::vector<ceres::Solver::Summary> solver_summaries;
+};
+
 }  // namespace map_optimization
 
 #endif  // MAP_OPTIMIZATION_OPTIMIZATION_PROBLEM_H_

--- a/algorithms/map-optimization/include/map-optimization/outlier-rejection-solver.h
+++ b/algorithms/map-optimization/include/map-optimization/outlier-rejection-solver.h
@@ -76,5 +76,10 @@ ceres::TerminationType solveWithOutlierRejection(
     OptimizationProblem* optimization_problem,
     OptimizationProblemResult* result);
 
+ceres::TerminationType solveWithOutlierRejection(
+    const ceres::Solver::Options& solver_options,
+    const OutlierRejectionSolverOptions& rejection_options,
+    OptimizationProblem* optimization_problem);
+
 }  // namespace map_optimization
 #endif  // MAP_OPTIMIZATION_OUTLIER_REJECTION_SOLVER_H_

--- a/algorithms/map-optimization/include/map-optimization/outlier-rejection-solver.h
+++ b/algorithms/map-optimization/include/map-optimization/outlier-rejection-solver.h
@@ -17,19 +17,16 @@ struct OutlierRejectionSolverOptions {
   // Run an outlier rejection loop every n iterations. Landmarks behind the
   // camera will be removed from the problem and flagged as kBad. Optionally,
   // landmarks are removed based on the reprojection errors.
-  int reject_outliers_every_n_iters;
+  int reject_outliers_every_n_iters = 3;
 
   // Classify and remove landmarks based on reprojection errors.
-  bool reject_landmarks_based_on_reprojection_errors;
+  bool reject_landmarks_based_on_reprojection_errors = false;
   // Reprojection error threshold for landmarks based on observations within
   // missions.
-  double reprojection_error_same_mission_px;
+  double reprojection_error_same_mission_px = 50;
   // Reprojection error threshold for landmarks based on observations across
   // missions.
-  double reprojection_error_other_mission_px;
-
- protected:
-  OutlierRejectionSolverOptions() = default;
+  double reprojection_error_other_mission_px = 400;
 };
 
 class OutlierRejectionCallback : public ceres::IterationCallback {
@@ -41,7 +38,7 @@ class OutlierRejectionCallback : public ceres::IterationCallback {
   virtual ~OutlierRejectionCallback() {}
 
   ceres::CallbackReturnType operator()(const ceres::IterationSummary& summary) {
-    initial_trust_region_radius_ = summary.trust_region_radius;
+    iteration_summaries_.emplace_back(summary);
 
     if (iteration_ == 0) {
       VLOG_IF(0, !FLAGS_ba_hide_iterations_console_output)
@@ -60,8 +57,7 @@ class OutlierRejectionCallback : public ceres::IterationCallback {
           summary.relative_decrease, summary.trust_region_radius,
           summary.linear_solver_iterations, summary.iteration_time_in_seconds,
           summary.cumulative_time_in_seconds);
-      VLOG_IF(0, !FLAGS_ba_hide_iterations_console_output)
-          << output;
+      VLOG_IF(0, !FLAGS_ba_hide_iterations_console_output) << output;
 
       ++iteration_;
     }
@@ -70,12 +66,15 @@ class OutlierRejectionCallback : public ceres::IterationCallback {
 
   int iteration_;
   double initial_trust_region_radius_;
+
+  std::vector<ceres::IterationSummary> iteration_summaries_;
 };
 
 ceres::TerminationType solveWithOutlierRejection(
     const ceres::Solver::Options& solver_options,
     const OutlierRejectionSolverOptions& rejection_options,
-    OptimizationProblem* optimization_problem);
+    OptimizationProblem* optimization_problem,
+    OptimizationProblemResult* result);
 
 }  // namespace map_optimization
 #endif  // MAP_OPTIMIZATION_OUTLIER_REJECTION_SOLVER_H_

--- a/algorithms/map-optimization/include/map-optimization/solver-options.h
+++ b/algorithms/map-optimization/include/map-optimization/solver-options.h
@@ -10,32 +10,62 @@
 DECLARE_int32(ba_num_iterations);
 DECLARE_int32(ba_max_time_seconds);
 DECLARE_bool(ba_enable_signal_handler);
-DECLARE_bool(ba_use_cgnr_linear_solver);
+DECLARE_string(ba_linear_solver_type);
 DECLARE_bool(ba_use_jacobi_scaling);
+DECLARE_bool(ba_use_nonmonotonic_steps);
+DECLARE_int32(ba_max_consecutive_nonmonotonic_steps);
+DECLARE_double(ba_initial_trust_region_radius);
+DECLARE_double(ba_max_trust_region_radius);
+DECLARE_double(ba_min_trust_region_radius);
+DECLARE_double(ba_function_tolerance);
+DECLARE_double(ba_gradient_tolerance);
+DECLARE_double(ba_parameter_tolerance);
+DECLARE_string(ba_sparse_linear_algebra_library_type);
 
 namespace map_optimization {
-
 inline ceres::Solver::Options initSolverOptionsFromFlags() {
   ceres::Solver::Options options;
   options.minimizer_progress_to_stdout = true;
   options.max_num_iterations = FLAGS_ba_num_iterations;
   options.max_solver_time_in_seconds = FLAGS_ba_max_time_seconds;
-  options.function_tolerance = 1e-12;
-  options.gradient_tolerance = 1e-10;
-  options.parameter_tolerance = 1e-8;
-  options.num_threads = common::getNumHardwareThreads();
+  options.function_tolerance = FLAGS_ba_function_tolerance;
+  options.gradient_tolerance = FLAGS_ba_gradient_tolerance;
+  options.parameter_tolerance = FLAGS_ba_parameter_tolerance;
+  options.use_nonmonotonic_steps = FLAGS_ba_use_nonmonotonic_steps;
+  options.max_consecutive_nonmonotonic_steps =
+      FLAGS_ba_max_consecutive_nonmonotonic_steps;
+  options.num_threads =
+      std::max(1u, static_cast<uint32_t>(common::getNumHardwareThreads() / 2u));
   options.jacobi_scaling = FLAGS_ba_use_jacobi_scaling;
-  options.initial_trust_region_radius = 1e5;
-  options.max_trust_region_radius = 1e20;
+  options.initial_trust_region_radius = FLAGS_ba_initial_trust_region_radius;
+  options.max_trust_region_radius = FLAGS_ba_max_trust_region_radius;
+  options.min_trust_region_radius = FLAGS_ba_min_trust_region_radius;
 
-  options.trust_region_strategy_type = ceres::LEVENBERG_MARQUARDT;
-  if (FLAGS_ba_use_cgnr_linear_solver) {
-    options.linear_solver_type = ceres::CGNR;
+  if (FLAGS_ba_sparse_linear_algebra_library_type == "SUITE_SPARSE") {
+    options.sparse_linear_algebra_library_type = ceres::SUITE_SPARSE;
+  } else if (FLAGS_ba_sparse_linear_algebra_library_type == "CX_SPARSE") {
+    options.sparse_linear_algebra_library_type = ceres::CX_SPARSE;
+  } else if (FLAGS_ba_sparse_linear_algebra_library_type == "EIGEN_SPARSE") {
+    options.sparse_linear_algebra_library_type = ceres::EIGEN_SPARSE;
   } else {
-    options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+    LOG(FATAL) << "Unkown type for --ba_sparse_linear_algebra_library_type: "
+               << "'" << FLAGS_ba_sparse_linear_algebra_library_type << "'!";
   }
 
-  options.sparse_linear_algebra_library_type = ceres::SUITE_SPARSE;
+  options.trust_region_strategy_type = ceres::LEVENBERG_MARQUARDT;
+
+  if (FLAGS_ba_linear_solver_type == "CGNR") {
+    options.linear_solver_type = ceres::CGNR;
+  } else if (FLAGS_ba_linear_solver_type == "SPARSE_NORMAL_CHOLESKY") {
+    options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+  } else if (FLAGS_ba_linear_solver_type == "SPARSE_SCHUR") {
+    options.linear_solver_type = ceres::SPARSE_SCHUR;
+  } else if (FLAGS_ba_linear_solver_type == "ITERATIVE_SCHUR") {
+    options.linear_solver_type = ceres::ITERATIVE_SCHUR;
+  } else {
+    LOG(FATAL) << "Unkown type for --ba_linear_solver_type: "
+               << "'" << FLAGS_ba_linear_solver_type << "'!";
+  }
 
   // Do not copy the data back at every iteration. Remember to turn it on if
   // any callbacks consuming this data are added later.

--- a/algorithms/map-optimization/include/map-optimization/solver.h
+++ b/algorithms/map-optimization/include/map-optimization/solver.h
@@ -19,7 +19,11 @@ class IterationSummaryCallback : public ceres::IterationCallback {
 ceres::TerminationType solve(
     const ceres::Solver::Options& solver_options,
     map_optimization::OptimizationProblem* optimization_problem,
-    OptimizationProblemResult* result = nullptr);
+    OptimizationProblemResult* result);
+
+ceres::TerminationType solve(
+    const ceres::Solver::Options& solver_options,
+    map_optimization::OptimizationProblem* optimization_problem);
 
 }  // namespace map_optimization
 #endif  // MAP_OPTIMIZATION_SOLVER_H_

--- a/algorithms/map-optimization/include/map-optimization/solver.h
+++ b/algorithms/map-optimization/include/map-optimization/solver.h
@@ -5,9 +5,21 @@
 
 namespace map_optimization {
 
+class IterationSummaryCallback : public ceres::IterationCallback {
+ public:
+  virtual ~IterationSummaryCallback() {}
+
+  ceres::CallbackReturnType operator()(const ceres::IterationSummary& summary) {
+    iteration_summaries.emplace_back(summary);
+    return ceres::SOLVER_CONTINUE;
+  }
+  std::vector<ceres::IterationSummary> iteration_summaries;
+};
+
 ceres::TerminationType solve(
     const ceres::Solver::Options& solver_options,
-    map_optimization::OptimizationProblem* optimization_problem);
+    map_optimization::OptimizationProblem* optimization_problem,
+    OptimizationProblemResult* result = nullptr);
 
 }  // namespace map_optimization
 #endif  // MAP_OPTIMIZATION_SOLVER_H_

--- a/algorithms/map-optimization/include/map-optimization/vi-map-optimizer.h
+++ b/algorithms/map-optimization/include/map-optimization/vi-map-optimizer.h
@@ -26,18 +26,8 @@ class VIMapOptimizer {
 
   bool optimize(
       const map_optimization::ViProblemOptions& options,
-      const vi_map::MissionIdSet& missions_to_optimize,
-      const map_optimization::OutlierRejectionSolverOptions* const
-          outlier_rejection_options,
-      vi_map::VIMap* map);
-
-  bool optimize(
-      const map_optimization::ViProblemOptions& options,
-      const ceres::Solver::Options& solver_options,
-      const vi_map::MissionIdSet& missions_to_optimize,
-      const map_optimization::OutlierRejectionSolverOptions* const
-          outlier_rejection_options,
-      vi_map::VIMap* map);
+      const vi_map::MissionIdSet& missions_to_optimize, vi_map::VIMap* map,
+      OptimizationProblemResult* result = nullptr);
 
  private:
   const visualization::ViwlsGraphRvizPlotter* plotter_;

--- a/algorithms/map-optimization/include/map-optimization/vi-map-optimizer.h
+++ b/algorithms/map-optimization/include/map-optimization/vi-map-optimizer.h
@@ -27,7 +27,11 @@ class VIMapOptimizer {
   bool optimize(
       const map_optimization::ViProblemOptions& options,
       const vi_map::MissionIdSet& missions_to_optimize, vi_map::VIMap* map,
-      OptimizationProblemResult* result = nullptr);
+      OptimizationProblemResult* result);
+
+  bool optimize(
+      const map_optimization::ViProblemOptions& options,
+      const vi_map::MissionIdSet& missions_to_optimize, vi_map::VIMap* map);
 
  private:
   const visualization::ViwlsGraphRvizPlotter* plotter_;

--- a/algorithms/map-optimization/include/map-optimization/vi-optimization-builder.h
+++ b/algorithms/map-optimization/include/map-optimization/vi-optimization-builder.h
@@ -5,6 +5,7 @@
 #include <vi-map-helpers/vi-map-queries.h>
 #include <vi-map/vi-map.h>
 
+#include <ceres/ceres.h>
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
@@ -12,6 +13,8 @@
 
 #include "map-optimization/optimization-problem.h"
 #include "map-optimization/optimization-terms-addition.h"
+#include "map-optimization/outlier-rejection-solver.h"
+#include "map-optimization/solver-options.h"
 
 namespace map_optimization {
 
@@ -49,8 +52,16 @@ struct ViProblemOptions {
 
   bool add_loop_closure_edges;
 
+  bool enable_visual_outlier_rejection;
+  map_optimization::OutlierRejectionSolverOptions
+      visual_outlier_rejection_options;
+
+  ceres::Solver::Options solver_options;
+
   bool isValid() const {
-    return (gravity_magnitude > 0.0);
+    bool is_valid = true;
+    is_valid &= (gravity_magnitude > 0.0);
+    return is_valid;
   }
 
   void printToConsole(const int verbosity_level = 3) {

--- a/algorithms/map-optimization/src/outlier-rejection-solver.cc
+++ b/algorithms/map-optimization/src/outlier-rejection-solver.cc
@@ -233,6 +233,15 @@ OutlierRejectionSolverOptions OutlierRejectionSolverOptions::initFromFlags() {
 ceres::TerminationType solveWithOutlierRejection(
     const ceres::Solver::Options& solver_options,
     const OutlierRejectionSolverOptions& rejection_options,
+    OptimizationProblem* optimization_problem) {
+  return solveWithOutlierRejection(
+      solver_options, rejection_options, optimization_problem,
+      nullptr /*result*/);
+}
+
+ceres::TerminationType solveWithOutlierRejection(
+    const ceres::Solver::Options& solver_options,
+    const OutlierRejectionSolverOptions& rejection_options,
     OptimizationProblem* optimization_problem,
     OptimizationProblemResult* result) {
   CHECK_NOTNULL(optimization_problem);

--- a/algorithms/map-optimization/src/outlier-rejection-solver.cc
+++ b/algorithms/map-optimization/src/outlier-rejection-solver.cc
@@ -277,7 +277,7 @@ ceres::TerminationType solveWithOutlierRejection(
     num_iters_remaining -= step_iters;
   }
 
-  // Safe all iteration summaries.
+  // Save all iteration summaries.
   if (result != nullptr) {
     result->iteration_summaries = callback.iteration_summaries_;
   }

--- a/algorithms/map-optimization/src/solver-options.cc
+++ b/algorithms/map-optimization/src/solver-options.cc
@@ -1,7 +1,8 @@
 #include "map-optimization/solver-options.h"
 
 DEFINE_int32(ba_num_iterations, 30, "Max. number of iterations.");
-DEFINE_int32(ba_max_time_seconds, 1e6, 
+DEFINE_int32(
+    ba_max_time_seconds, 1e6,
     "Maximum amount of time for which the solver should run.");
 DEFINE_bool(
     ba_enable_signal_handler, true,
@@ -9,4 +10,43 @@ DEFINE_bool(
     "the user to abort the optimization after the next iterations with "
     "Ctrl-C.");
 DEFINE_bool(ba_use_jacobi_scaling, true, "Use jacobin scaling.");
-DEFINE_bool(ba_use_cgnr_linear_solver, false, "Use CGNR linear solver?");
+DEFINE_string(
+    ba_linear_solver_type, "SPARSE_NORMAL_CHOLESKY",
+    "Options: 'CGNR', 'SPARSE_NORMAL_CHOLESKY', 'SPARSE_SCHUR', "
+    "'ITERATIVE_SCHUR'.");
+DEFINE_bool(
+    ba_use_nonmonotonic_steps, false,
+    "If enabled, the objective function is allowed to get worse for a max "
+    "number of steps define with --ba_max_consecutive_nonmonotonic_steps. "
+    "The idea is that in the long run the optimization is able to 'jump over "
+    "boulders' in an attempt to find a better solution. (Ceres default: "
+    "false)");
+DEFINE_int32(
+    ba_max_consecutive_nonmonotonic_steps, 5,
+    "Maximum number of steps where the cost is increasing. This only has an "
+    "effect if --ba_use_nonmonotonic_steps is enabled. (Ceres default: 5)");
+DEFINE_double(
+    ba_initial_trust_region_radius, 1e5,
+    "Initial radius of trust region. (Ceres default: 1e4)");
+DEFINE_double(
+    ba_max_trust_region_radius, 1e20,
+    "Maximum radius of trust region. (Ceres default: 1e16)");
+DEFINE_double(
+    ba_min_trust_region_radius, 1e-32,
+    "Minimum radius of trust region. (Ceres default: 1e-32)");
+DEFINE_double(
+    ba_function_tolerance, 1e-12,
+    "The minimizer terminates if (new_cost - old_cost) < function_tolerance * "
+    "old_cost. (Ceres default: 1e-6)");
+DEFINE_double(
+    ba_gradient_tolerance, 1e-10,
+    "The minimizer terminates if: max_i |x - Project(Plus(x, -g(x))| < "
+    "gradient_tolerance. (Ceres default: 1e-10)");
+DEFINE_double(
+    ba_parameter_tolerance, 1e-8,
+    "The minimizer terminates if: |step|_2 <= parameter_tolerance * ( |x|_2 +  "
+    "parameter_tolerance). (Ceres default: 1e-8)");
+DEFINE_string(
+    ba_sparse_linear_algebra_library_type, "SUITE_SPARSE",
+    "Default: The highest available according to: SUITE_SPARSE > CX_SPARSE > "
+    "EIGEN_SPARSE > NO_SPARSE");

--- a/algorithms/map-optimization/src/solver.cc
+++ b/algorithms/map-optimization/src/solver.cc
@@ -7,12 +7,21 @@ namespace map_optimization {
 
 ceres::TerminationType solve(
     const ceres::Solver::Options& solver_options,
-    map_optimization::OptimizationProblem* optimization_problem) {
+    map_optimization::OptimizationProblem* optimization_problem,
+    OptimizationProblemResult* result) {
   CHECK_NOTNULL(optimization_problem);
+  // 'result' cam be a nullptr
 
   ceres::Problem problem(ceres_error_terms::getDefaultProblemOptions());
   ceres_error_terms::buildCeresProblemFromProblemInformation(
       optimization_problem->getProblemInformationMutable(), &problem);
+
+  IterationSummaryCallback callback;
+  ceres::Solver::Options local_options = solver_options;
+  if (result != nullptr) {
+    // Install callback to retrieve IterationSummaries.
+    local_options.callbacks.push_back(&callback);
+  }
 
   ceres::Solver::Summary summary;
   ceres::Solve(solver_options, &problem, &summary);
@@ -20,7 +29,11 @@ ceres::TerminationType solve(
   optimization_problem->getOptimizationStateBufferMutable()
       ->copyAllStatesBackToMap(optimization_problem->getMapMutable());
 
-  LOG(INFO) << summary.FullReport();
+  if (result != nullptr) {
+    result->iteration_summaries = callback.iteration_summaries;
+    result->solver_summaries.emplace_back(summary);
+  }
+
   return summary.termination_type;
 }
 

--- a/algorithms/map-optimization/src/solver.cc
+++ b/algorithms/map-optimization/src/solver.cc
@@ -7,6 +7,12 @@ namespace map_optimization {
 
 ceres::TerminationType solve(
     const ceres::Solver::Options& solver_options,
+    map_optimization::OptimizationProblem* optimization_problem) {
+  return solve(solver_options, optimization_problem, nullptr /*result*/);
+}
+
+ceres::TerminationType solve(
+    const ceres::Solver::Options& solver_options,
     map_optimization::OptimizationProblem* optimization_problem,
     OptimizationProblemResult* result) {
   CHECK_NOTNULL(optimization_problem);

--- a/algorithms/map-optimization/src/vi-map-optimizer.cc
+++ b/algorithms/map-optimization/src/vi-map-optimizer.cc
@@ -27,6 +27,12 @@ VIMapOptimizer::VIMapOptimizer(
 
 bool VIMapOptimizer::optimize(
     const map_optimization::ViProblemOptions& options,
+    const vi_map::MissionIdSet& missions_to_optimize, vi_map::VIMap* map) {
+  return optimize(options, missions_to_optimize, map, nullptr /*result*/);
+}
+
+bool VIMapOptimizer::optimize(
+    const map_optimization::ViProblemOptions& options,
     const vi_map::MissionIdSet& missions_to_optimize, vi_map::VIMap* map,
     OptimizationProblemResult* result) {
   // 'result' can be a nullptr.

--- a/algorithms/map-optimization/src/vi-map-optimizer.cc
+++ b/algorithms/map-optimization/src/vi-map-optimizer.cc
@@ -27,28 +27,9 @@ VIMapOptimizer::VIMapOptimizer(
 
 bool VIMapOptimizer::optimize(
     const map_optimization::ViProblemOptions& options,
-    const vi_map::MissionIdSet& missions_to_optimize,
-    const map_optimization::OutlierRejectionSolverOptions* const
-        outlier_rejection_options,
-    vi_map::VIMap* map) {
-  // outlier_rejection_options is optional.
-  CHECK_NOTNULL(map);
-
-  ceres::Solver::Options solver_options =
-      map_optimization::initSolverOptionsFromFlags();
-  return optimize(
-      options, solver_options, missions_to_optimize, outlier_rejection_options,
-      map);
-}
-
-bool VIMapOptimizer::optimize(
-    const map_optimization::ViProblemOptions& options,
-    const ceres::Solver::Options& solver_options,
-    const vi_map::MissionIdSet& missions_to_optimize,
-    const map_optimization::OutlierRejectionSolverOptions* const
-        outlier_rejection_options,
-    vi_map::VIMap* map) {
-  // outlier_rejection_options is optional.
+    const vi_map::MissionIdSet& missions_to_optimize, vi_map::VIMap* map,
+    OptimizationProblemResult* result) {
+  // 'result' can be a nullptr.
   CHECK_NOTNULL(map);
 
   if (missions_to_optimize.empty()) {
@@ -71,17 +52,17 @@ bool VIMapOptimizer::optimize(
   if (FLAGS_ba_enable_signal_handler) {
     map_optimization::appendSignalHandlerCallback(&callbacks);
   }
-  ceres::Solver::Options solver_options_with_callbacks = solver_options;
+  ceres::Solver::Options solver_options_with_callbacks = options.solver_options;
   map_optimization::addCallbacksToSolverOptions(
       callbacks, &solver_options_with_callbacks);
 
-  if (outlier_rejection_options != nullptr) {
+  if (options.enable_visual_outlier_rejection) {
     map_optimization::solveWithOutlierRejection(
-        solver_options_with_callbacks, *outlier_rejection_options,
-        optimization_problem.get());
+        solver_options_with_callbacks, options.visual_outlier_rejection_options,
+        optimization_problem.get(), result);
   } else {
     map_optimization::solve(
-        solver_options_with_callbacks, optimization_problem.get());
+        solver_options_with_callbacks, optimization_problem.get(), result);
   }
 
   if (plotter_ != nullptr) {

--- a/algorithms/map-optimization/src/vi-optimization-builder.cc
+++ b/algorithms/map-optimization/src/vi-optimization-builder.cc
@@ -9,6 +9,9 @@
 DEFINE_bool(
     ba_include_visual, true, "Whether or not to include visual error-terms.");
 DEFINE_bool(
+    ba_use_visual_outlier_rejection_solver, true,
+    "Reject outlier landmarks during the solve?");
+DEFINE_bool(
     ba_include_inertial, true, "Whether or not to include IMU error-terms.");
 DEFINE_bool(
     ba_include_wheel_odometry, false,
@@ -130,6 +133,13 @@ ViProblemOptions ViProblemOptions::initFromGFlags() {
 
   // Loop closure constraints (can be from an external source)
   options.add_loop_closure_edges = FLAGS_ba_include_loop_closure_edges;
+
+  options.solver_options = initSolverOptionsFromFlags();
+
+  options.enable_visual_outlier_rejection =
+      FLAGS_ba_use_visual_outlier_rejection_solver;
+  options.visual_outlier_rejection_options =
+      map_optimization::OutlierRejectionSolverOptions::initFromFlags();
 
   options.printToConsole();
 

--- a/algorithms/map-optimization/test/test-optimization.cc
+++ b/algorithms/map-optimization/test/test-optimization.cc
@@ -127,10 +127,7 @@ bool ViMappingTest::optimize(
 
   vi_map::MissionIdSet mission_ids;
   map->getAllMissionIds(&mission_ids);
-
-  map_optimization::OutlierRejectionSolverOptions rejection_options =
-      map_optimization::OutlierRejectionSolverOptions::initFromFlags();
-  return optimizer.optimize(options, mission_ids, &rejection_options, map);
+  return optimizer.optimize(options, mission_ids, map);
 }
 
 void ViMappingTest::testWheelCalibrationThreeVertices() {
@@ -237,18 +234,14 @@ void ViMappingTest::testWheelCalibrationThreeVertices() {
   map->addEdge(std::move(edge_B_C));
 
   // OPTIMIZE
-  ceres::Solver::Options solver_options =
-      map_optimization::initSolverOptionsFromFlags();
-  solver_options.max_num_iterations = 60;
-
+  options.solver_options.max_num_iterations = 60;
   options.add_inertial_constraints = false;
   options.add_visual_constraints = false;
   options.add_wheel_odometry_constraints = true;
+
   visualization::ViwlsGraphRvizPlotter* plotter = nullptr;
   constexpr bool kSignalHandlerEnabled = false;
   map_optimization::VIMapOptimizer optimizer(plotter, kSignalHandlerEnabled);
-  map_optimization::OutlierRejectionSolverOptions rejection_options =
-      map_optimization::OutlierRejectionSolverOptions::initFromFlags();
 
   vi_map::MissionIdSet mission_ids;
   map->getAllMissionIds(&mission_ids);
@@ -257,7 +250,7 @@ void ViMappingTest::testWheelCalibrationThreeVertices() {
       map_optimization::constructOptimizationProblem(
           mission_ids, options, map.get()));
 
-  map_optimization::solve(solver_options, optimization_problem.get());
+  map_optimization::solve(options.solver_options, optimization_problem.get());
 
   // RESULTS
   aslam::Transformation T_S_B_opt =
@@ -392,11 +385,10 @@ void ViMappingTest::testWheelCalibrationTwoVertices() {
   options.add_inertial_constraints = false;
   options.add_visual_constraints = false;
   options.add_wheel_odometry_constraints = true;
+
   visualization::ViwlsGraphRvizPlotter* plotter = nullptr;
   constexpr bool kSignalHandlerEnabled = false;
   map_optimization::VIMapOptimizer optimizer(plotter, kSignalHandlerEnabled);
-  map_optimization::OutlierRejectionSolverOptions rejection_options =
-      map_optimization::OutlierRejectionSolverOptions::initFromFlags();
 
   vi_map::MissionIdSet mission_ids;
   map->getAllMissionIds(&mission_ids);
@@ -405,7 +397,7 @@ void ViMappingTest::testWheelCalibrationTwoVertices() {
       map_optimization::constructOptimizationProblem(
           mission_ids, options, map.get()));
 
-  map_optimization::solve(solver_options, optimization_problem.get());
+  map_optimization::solve(options.solver_options, optimization_problem.get());
 
   // RESULTS
   aslam::Transformation T_S_B_opt =

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -948,9 +948,6 @@ void MaplabServerNode::runSubmapProcessingCommands(
     // later the optimization settings for the submaps remain the same.
     static map_optimization::ViProblemOptions options =
         map_optimization::ViProblemOptions::initFromGFlags();
-    static map_optimization::OutlierRejectionSolverOptions
-        outlier_rejection_options =
-            map_optimization::OutlierRejectionSolverOptions::initFromFlags();
 
     vi_map::VIMapManager map_manager;
     vi_map::VIMapManager::MapWriteAccess map =
@@ -996,8 +993,7 @@ void MaplabServerNode::runSubmapProcessingCommands(
         missions_to_optimize_list.begin(), missions_to_optimize_list.end());
     map_optimization::VIMapOptimizer optimizer(
         nullptr /*no plotter*/, false /*signal handler enabled*/);
-    optimizer.optimize(
-        options, missions_to_optimize, &outlier_rejection_options, map.get());
+    optimizer.optimize(options, missions_to_optimize, map.get());
 
     if (FLAGS_maplab_server_remove_outliers_in_absolute_pose_constraints) {
       std::lock_guard<std::mutex> command_lock(submap_commands_mutex_);

--- a/console-plugins/loop-closure-plugin/test/test-loopclosure.cc
+++ b/console-plugins/loop-closure-plugin/test/test-loopclosure.cc
@@ -35,7 +35,7 @@ class LoopClosureAppTest : public ::testing::Test {
         new VIMapMerger(test_app_.getMapMutable(), kPlotterNullptr));
   }
 
-  bool optimize(ceres::Solver::Summary* summary);
+  bool optimize();
 
   visual_inertial_mapping::VIMappingTestApp test_app_;
   std::unique_ptr<VIMapMerger> map_merger_;

--- a/console-plugins/map-optimization-plugin/include/map-optimization-plugin/optimizer-plugin.h
+++ b/console-plugins/map-optimization-plugin/include/map-optimization-plugin/optimizer-plugin.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <console-common/console-plugin-base-with-plotter.h>
+#include <map-optimization/vi-optimization-builder.h>
 #include <vi-map-data-import-export/import-loop-closure-edges.h>
 #include <vi-map/vi-map.h>
 
@@ -28,7 +29,7 @@ class OptimizerPlugin : public common::ConsolePluginBaseWithPlotter {
   }
 
  private:
-  int optimize(bool visual_only, bool outlier_rejection);
+  int optimize(const map_optimization::ViProblemOptions& options);
 
   int relaxMap();
   int relaxMapMissionsSeparately();

--- a/console-plugins/map-optimization-plugin/src/optimizer-plugin.cc
+++ b/console-plugins/map-optimization-plugin/src/optimizer-plugin.cc
@@ -25,7 +25,7 @@ OptimizerPlugin::OptimizerPlugin(
     common::Console* console, visualization::ViwlsGraphRvizPlotter* plotter)
     : common::ConsolePluginBaseWithPlotter(console, plotter) {
   addCommand(
-      {"noptimize_visual", "optv"},
+      {"optimize_visual", "optv"},
       [this]() -> int {
         map_optimization::ViProblemOptions options =
             map_optimization::ViProblemOptions::initFromGFlags();

--- a/console-plugins/map-optimization-plugin/src/optimizer-plugin.cc
+++ b/console-plugins/map-optimization-plugin/src/optimizer-plugin.cc
@@ -32,7 +32,6 @@ OptimizerPlugin::OptimizerPlugin(
 
         // The only difference to the default behaviour of the optimization is
         // to disable inertial constraints.
-
         options.add_inertial_constraints = false;
 
         return optimize(options);


### PR DESCRIPTION
**Note: this PR does not change the default behavior of the optimization.**

This PR was motivated by an issue we encountered when running optimization in multiple parallel threads. The fact that the parameters are initialized inside the package based on gflags resulted in interdependencies between the thread parameters, i.e. they had to be the same, as the gflags are shared across all the processes. Another issue was that we wanted to run a couple of iterations, then do something and run some more iterations on the same map. But since the optimization would not preserve or expose any of the variables such as the current trust region radius, the optimization would always start from scratch, despite the fact that we know on the outside that the map is still the same, so if we had access to these parameters we could make the optimization continue where it left off (at least what the parameters are concerned).

Changes: 
  - Expose more solver options as gflags to be able to tune
       - Why: because it allows us to better tune the optimization to a specific use-case.
  - Make cares::Solver::Options and the OutlierRejectionSolverOptions members of the main optimization options struct.
    - Why: Before these options would be initialized based on gflags somewhere inside the optimization package. By moving them into members of the outermost options struct, there have now become configurable programmatically from outside the optimization package.
 - Add optional output struct that captures the IteratiionSummary and Solver::Summary during the optimization.
    - Why:  It allows for better introspection from the outside without hacking in log statements into the optimization package. Also, variables like the trust region radius of the final iteration can be retrieved after the optimization.
