### PR TITLE
Bugfix in temporal buffer

### DIFF
--- a/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
+++ b/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
@@ -437,7 +437,8 @@ size_t TemporalBuffer<ValueType, AllocatorType>::
 
   // Get first iterator that is greater than the timestamp, i.e. everything
   // between begin() and this iterator is what we want.
-  auto first_newer_timestamp_it = values_.upper_bound(timestamp_ns);
+  typename BufferType::iterator first_newer_timestamp_it =
+		  values_.upper_bound(timestamp_ns);
 
   // Copy values earlier or equal to the timestamp.
   std::transform(

--- a/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
+++ b/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
@@ -400,7 +400,8 @@ size_t TemporalBuffer<ValueType, AllocatorType>::extractItemsBeforeIncluding(
 
   // Get first iterator that is greater than the timestamp, i.e. everything
   // between begin() and this iterator is what we want.
-  auto first_newer_timestamp_it = values_.upper_bound(timestamp_ns);
+  typename BufferType::iterator first_newer_timestamp_it =
+		  values_.upper_bound(timestamp_ns);
 
   // Copy values to be removed.
   std::transform(

--- a/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
+++ b/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
@@ -406,7 +406,9 @@ size_t TemporalBuffer<ValueType, AllocatorType>::extractItemsBeforeIncluding(
   std::transform(
       values_.begin(), first_newer_timestamp_it,
       std::back_inserter(*removed_values),
-      [](auto stamped_value) { return stamped_value.second; });
+      [](const typename BufferType::value_type& stamped_value) {
+	  return stamped_value.second;
+  });
 
   // Erase values.
   values_.erase(values_.begin(), first_newer_timestamp_it);

--- a/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
+++ b/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
@@ -440,7 +440,9 @@ size_t TemporalBuffer<ValueType, AllocatorType>::
   std::transform(
       values_.begin(), first_newer_timestamp_it,
       std::back_inserter(*returned_values),
-      [](auto stamped_value) { return stamped_value.second; });
+      [](const typename BufferType::value_type& stamped_value) {
+	  return stamped_value.second;
+  });
 
   // Remove values that were returned, except for the newest one.
   const size_t size_before = values_.size();

--- a/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
+++ b/common/maplab-common/include/maplab-common/temporal-buffer-inl.h
@@ -391,69 +391,63 @@ size_t TemporalBuffer<ValueType, AllocatorType>::extractItemsBeforeIncluding(
     return 0u;
   }
 
-  if (values_.begin()->first < timestamp_ns) {
-    typename BufferType::const_iterator it = values_.lower_bound(timestamp_ns);
-
-    // If all values in the buffer should be removed we don't need to move the
-    // iterator another step.
-    CHECK(it != values_.begin());
-    if (it != values_.end()) {
-      it = std::next(it);
-    }
-
-    const size_t size_before = values_.size();
-
-    // Copy values to be removed.
-    typename BufferType::const_iterator local_it = values_.begin();
-    while (local_it != it) {
-      removed_values->emplace_back(local_it->second);
-      ++local_it;
-    }
-
-    // Remove values.
-    values_.erase(values_.begin(), it);
-    const size_t num_elements_erased = size_before - values_.size();
-    CHECK_EQ(num_elements_erased, removed_values->size());
-    return num_elements_erased;
+  // If timestamp is older than oldest timestamp, then there is nothing to
+  // return.
+  if (timestamp_ns < values_.begin()->first) {
+    return 0u;
   }
-  return 0u;
+  // Otherwise there is at least one element that is equal or older.
+
+  // Get first iterator that is greater than the timestamp, i.e. everything
+  // between begin() and this iterator is what we want.
+  auto first_newer_timestamp_it = values_.upper_bound(timestamp_ns);
+
+  // Copy values to be removed.
+  std::transform(
+      values_.begin(), first_newer_timestamp_it,
+      std::back_inserter(*removed_values),
+      [](auto stamped_value) { return stamped_value.second; });
+
+  // Erase values.
+  values_.erase(values_.begin(), first_newer_timestamp_it);
+
+  return removed_values->size();
 }
 
 template <typename ValueType, typename AllocatorType>
 template <typename ValueContainerType>
 size_t TemporalBuffer<ValueType, AllocatorType>::
     extractItemsBeforeIncludingKeepMostRecent(
-        const int64_t timestamp_ns, ValueContainerType* earlier_values) {
+        const int64_t timestamp_ns, ValueContainerType* returned_values) {
+  CHECK_NOTNULL(returned_values)->clear();
+
   if (empty()) {
     return 0u;
   }
 
-  if (values_.begin()->first < timestamp_ns) {
-    typename BufferType::const_iterator it = values_.lower_bound(timestamp_ns);
-
-    // If all values in the buffer should be removed we don't need to move the
-    // iterator another step.
-    CHECK(it != values_.begin());
-    if (it != values_.end()) {
-      it = std::next(it);
-    }
-
-    const size_t size_before = values_.size();
-
-    // Copy values to be removed.
-    typename BufferType::const_iterator local_it = values_.begin();
-    while (local_it != it) {
-      earlier_values->emplace_back(local_it->second);
-      ++local_it;
-    }
-
-    // Remove values.
-    values_.erase(values_.begin(), std::prev(it));
-    const size_t num_elements_erased = size_before - values_.size();
-    CHECK_EQ(num_elements_erased, earlier_values->size() - 1);
-    return num_elements_erased;
+  // If timestamp is older than oldest timestamp, then there is nothing to
+  // return.
+  if (timestamp_ns < values_.begin()->first) {
+    return 0u;
   }
-  return 0u;
+  // Otherwise there is at least one element that is equal or older.
+
+  // Get first iterator that is greater than the timestamp, i.e. everything
+  // between begin() and this iterator is what we want.
+  auto first_newer_timestamp_it = values_.upper_bound(timestamp_ns);
+
+  // Copy values earlier or equal to the timestamp.
+  std::transform(
+      values_.begin(), first_newer_timestamp_it,
+      std::back_inserter(*returned_values),
+      [](auto stamped_value) { return stamped_value.second; });
+
+  // Remove values that were returned, except for the newest one.
+  const size_t size_before = values_.size();
+  values_.erase(values_.begin(), std::prev(first_newer_timestamp_it));
+  const size_t num_elements_erased = size_before - values_.size();
+  CHECK_EQ(num_elements_erased, returned_values->size() - 1);
+  return num_elements_erased;
 }
 
 template <typename ValueType, typename AllocatorType>

--- a/common/maplab-common/include/maplab-common/temporal-buffer.h
+++ b/common/maplab-common/include/maplab-common/temporal-buffer.h
@@ -141,12 +141,15 @@ class TemporalBuffer {
 
   size_t removeItemsBefore(const int64_t timestamp_ns);
 
+  // Returns and removes all values with timestamp <= the provided threshold.
+  // The return value is equal to the number of returned/removed values.
   template <typename ValueContainerType>
   size_t extractItemsBeforeIncluding(
       const int64_t timestamp_ns, ValueContainerType* removed_values);
 
-  // in contrast to extractItemsBeforeIncluding(), last element with older ts
-  // than timestamp_ns is kept in buffer
+  // Returns all values with timestamp <= the provided threshold.
+  // Removes all returned values EXCEPT the newest one.
+  // The return value is equal to the number of REMOVED values.
   template <typename ValueContainerType>
   size_t extractItemsBeforeIncludingKeepMostRecent(
       const int64_t timestamp_ns, ValueContainerType* values);

--- a/common/maplab-common/test/test_temporal_buffer.cc
+++ b/common/maplab-common/test/test_temporal_buffer.cc
@@ -338,6 +338,59 @@ TEST_F(TemporalBufferFixture, RemovingAndRetrieveItemsByThreshold) {
   ASSERT_TRUE(removed_values.empty());
 }
 
+TEST_F(TemporalBufferFixture, RemovingAndRetrieveItemsByThresholdCornerCases) {
+  addValue(TestData(10));
+  addValue(TestData(20));
+  EXPECT_EQ(buffer_.size(), 2u);
+
+  std::vector<TestData> removed_values_2;
+  EXPECT_EQ(buffer_.extractItemsBeforeIncluding(15, &removed_values_2), 1u);
+  EXPECT_EQ(buffer_.size(), 1u);
+  ASSERT_EQ(removed_values_2.size(), 1u);
+  EXPECT_EQ(removed_values_2[0].timestamp, 10);
+}
+
+TEST_F(TemporalBufferFixture, TestExtractItemsBeforeIncludingKeepMostRecent) {
+  {
+    addValue(TestData(10));
+    addValue(TestData(20));
+    addValue(TestData(30));
+    addValue(TestData(40));
+    addValue(TestData(50));
+    EXPECT_EQ(buffer_.size(), 5u);
+
+    std::vector<TestData> removed_values;
+    EXPECT_EQ(
+        buffer_.extractItemsBeforeIncludingKeepMostRecent(30, &removed_values),
+        2u);
+    EXPECT_EQ(buffer_.size(), 3u);
+    ASSERT_EQ(removed_values.size(), 3u);
+    EXPECT_EQ(removed_values[0].timestamp, 10);
+    EXPECT_EQ(removed_values[1].timestamp, 20);
+    EXPECT_EQ(removed_values[2].timestamp, 30);
+  }
+
+  buffer_.clear();
+
+  {
+    addValue(TestData(10));
+    addValue(TestData(20));
+    addValue(TestData(30));
+    addValue(TestData(40));
+    addValue(TestData(50));
+    EXPECT_EQ(buffer_.size(), 5u);
+
+    std::vector<TestData> returned_values;
+    EXPECT_EQ(
+        buffer_.extractItemsBeforeIncludingKeepMostRecent(28, &returned_values),
+        1u);
+    EXPECT_EQ(buffer_.size(), 4u);
+    ASSERT_EQ(returned_values.size(), 2u);
+    EXPECT_EQ(returned_values[0].timestamp, 10);
+    EXPECT_EQ(returned_values[1].timestamp, 20);
+  }
+}
+
 TEST_F(TemporalBufferFixture, GetValuesFromIncludingToIncluding) {
   addValue(TestData(10));
   addValue(TestData(20));


### PR DESCRIPTION
There was a small bug in `extractItemsBeforeIncluding`, it was extracting  value that was newer than the threshold. The consequence was that the synchronizer of the maplab_node was releasing data a bit early sometimes. The corner cases should now be covered by the unit tests.