### PR TITLE
Image resizing

### DIFF
--- a/applications/maplab-node/src/maplab-node.cc
+++ b/applications/maplab-node/src/maplab-node.cc
@@ -43,6 +43,8 @@ DEFINE_int64(
     "Enable visualization of the visual localization observations and inliers "
     "as ROS message.");
 
+DECLARE_double(image_resize_factor);
+
 namespace maplab {
 MaplabNode::MaplabNode(
     const std::string& sensor_calibration_file,
@@ -64,6 +66,31 @@ MaplabNode::MaplabNode(
                << sensor_calibration_file << "'!";
   }
   CHECK(sensor_manager_);
+
+  // At the very beginning check if the main ncamera images need to be resized
+  aslam::NCamera::Ptr mapping_ncamera =
+      vi_map::getSelectedNCamera(*sensor_manager_);
+  if (mapping_ncamera && fabs(FLAGS_image_resize_factor - 1.0) > 1e-6) {
+    for (size_t i = 0; i < mapping_ncamera->getNumCameras(); i++) {
+      // The intrinsics of the camera can just be multiplied with the resize
+      // factor. Distortion parameters are agnostic to the image size
+      aslam::Camera::Ptr camera = mapping_ncamera->getCameraShared(i);
+      camera->setParameters(
+          camera->getParameters() * FLAGS_image_resize_factor);
+      camera->setImageWidth(
+          round(camera->imageWidth() * FLAGS_image_resize_factor));
+      camera->setImageHeight(
+          round(camera->imageHeight() * FLAGS_image_resize_factor));
+      camera->setDescription(
+          camera->getDescription() + " - resized " +
+          std::to_string(FLAGS_image_resize_factor));
+
+      // The parameters have changed so we need to generate a new sensor id
+      aslam::SensorId camera_id;
+      generateId(&camera_id);
+      camera->setId(camera_id);
+    }
+  }
 
   // === SYNCHRONIZER ===
   synchronizer_flow_.reset(new SynchronizerFlow(*sensor_manager_));

--- a/applications/maplab-node/src/maplab-node.cc
+++ b/applications/maplab-node/src/maplab-node.cc
@@ -67,13 +67,13 @@ MaplabNode::MaplabNode(
   }
   CHECK(sensor_manager_);
 
-  // At the very beginning check if the main ncamera images need to be resized
+  // At the very beginning check if the main ncamera images need to be resized.
   aslam::NCamera::Ptr mapping_ncamera =
       vi_map::getSelectedNCamera(*sensor_manager_);
   if (mapping_ncamera && fabs(FLAGS_image_resize_factor - 1.0) > 1e-6) {
     for (size_t i = 0; i < mapping_ncamera->getNumCameras(); i++) {
       // The intrinsics of the camera can just be multiplied with the resize
-      // factor. Distortion parameters are agnostic to the image size
+      // factor. Distortion parameters are agnostic to the image size.
       aslam::Camera::Ptr camera = mapping_ncamera->getCameraShared(i);
       camera->setParameters(
           camera->getParameters() * FLAGS_image_resize_factor);
@@ -85,7 +85,7 @@ MaplabNode::MaplabNode(
           camera->getDescription() + " - resized " +
           std::to_string(FLAGS_image_resize_factor));
 
-      // The parameters have changed so we need to generate a new sensor id
+      // The parameters have changed so we need to generate a new sensor id.
       aslam::SensorId camera_id;
       generateId(&camera_id);
       camera->setId(camera_id);

--- a/applications/maplab-node/src/ros-helpers.cc
+++ b/applications/maplab-node/src/ros-helpers.cc
@@ -40,6 +40,8 @@ DEFINE_bool(
     set_imu_bias_to_zero, false,
     "Setting IMU biases for odometry estimation to zero.");
 
+DEFINE_double(image_resize_factor, 1.0, "Factor to resize images.");
+
 namespace maplab {
 
 vio::ImuMeasurement::Ptr convertRosImuToMaplabImu(
@@ -111,6 +113,17 @@ vio::ImageMeasurement::Ptr convertRosImageToMaplabImage(
     LOG(FATAL) << "cv_bridge exception: " << e.what();
   }
   CHECK(cv_ptr);
+
+  if (fabs(FLAGS_image_resize_factor - 1.0) > 1e-6) {
+    int newcols =
+        round(image_measurement->image.cols * FLAGS_image_resize_factor);
+    int newrows =
+        round(image_measurement->image.rows * FLAGS_image_resize_factor);
+
+    cv::resize(
+        image_measurement->image, image_measurement->image,
+        cv::Size(newcols, newrows));
+  }
 
   image_measurement->timestamp =
       rosTimeToNanoseconds(image_message->header.stamp);

--- a/applications/maplab-node/src/ros-helpers.cc
+++ b/applications/maplab-node/src/ros-helpers.cc
@@ -115,9 +115,9 @@ vio::ImageMeasurement::Ptr convertRosImageToMaplabImage(
   CHECK(cv_ptr);
 
   if (fabs(FLAGS_image_resize_factor - 1.0) > 1e-6) {
-    int newcols =
+    const int newcols =
         round(image_measurement->image.cols * FLAGS_image_resize_factor);
-    int newrows =
+    const int newrows =
         round(image_measurement->image.rows * FLAGS_image_resize_factor);
 
     cv::resize(

--- a/applications/rovioli/app/rovioli-app.cc
+++ b/applications/rovioli/app/rovioli-app.cc
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include <aslam/cameras/ncamera.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <localization-summary-map/localization-summary-map-creation.h>
@@ -39,6 +40,7 @@ DEFINE_bool(
     optimize_map_to_localization_map, false,
     "Optimize and process the map into a localization map before "
     "saving it.");
+DECLARE_double(rovioli_image_resize_factor);
 
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
@@ -64,6 +66,29 @@ int main(int argc, char** argv) {
       << "[ROVIOLI] The sensor calibration does not contain a NCamera!";
   CHECK(vi_map::getSelectedImu(sensor_manager))
       << "[ROVIOLI] The sensor calibration does not contain an IMU!";
+
+  if (fabs(FLAGS_rovioli_image_resize_factor - 1.0) > 1e-6) {
+    aslam::NCamera::Ptr ncamera = vi_map::getSelectedNCamera(sensor_manager);
+    for (size_t i = 0; i < ncamera->getNumCameras(); i++) {
+      // The intrinsics of the camera can just be multiplied with the resize
+      // factor. Distortion parameters are agnostic to the image size
+      aslam::Camera::Ptr camera = ncamera->getCameraShared(i);
+      camera->setParameters(
+          camera->getParameters() * FLAGS_rovioli_image_resize_factor);
+      camera->setImageWidth(
+          round(camera->imageWidth() * FLAGS_rovioli_image_resize_factor));
+      camera->setImageHeight(
+          round(camera->imageHeight() * FLAGS_rovioli_image_resize_factor));
+      camera->setDescription(
+          camera->getDescription() + " - resized " +
+          std::to_string(FLAGS_rovioli_image_resize_factor));
+
+      // The parameters have changed so we need to generate a new sensor id
+      aslam::SensorId camera_id;
+      generateId(&camera_id);
+      camera->setId(camera_id);
+    }
+  }
 
   // Optionally load localization map.
   std::unique_ptr<summary_map::LocalizationSummaryMap> localization_map;

--- a/applications/rovioli/src/ros-helpers.cc
+++ b/applications/rovioli/src/ros-helpers.cc
@@ -111,9 +111,9 @@ vio::ImageMeasurement::Ptr convertRosImageToMaplabImage(
   CHECK(cv_ptr);
 
   if (fabs(FLAGS_rovioli_image_resize_factor - 1.0) > 1e-6) {
-    int newcols = round(
+    const int newcols = round(
         image_measurement->image.cols * FLAGS_rovioli_image_resize_factor);
-    int newrows = round(
+    const int newrows = round(
         image_measurement->image.rows * FLAGS_rovioli_image_resize_factor);
 
     cv::resize(

--- a/applications/rovioli/src/ros-helpers.cc
+++ b/applications/rovioli/src/ros-helpers.cc
@@ -35,6 +35,8 @@ DEFINE_double(
     "Shift applied to the scaled values when converting 16bit images to 8bit "
     "images.");
 
+DEFINE_double(rovioli_image_resize_factor, 1.0, "Factor to resize images.");
+
 namespace rovioli {
 vio::ImuMeasurement::Ptr convertRosImuToMaplabImu(
     const sensor_msgs::ImuConstPtr& imu_msg) {
@@ -107,6 +109,17 @@ vio::ImageMeasurement::Ptr convertRosImageToMaplabImage(
     LOG(FATAL) << "cv_bridge exception: " << e.what();
   }
   CHECK(cv_ptr);
+
+  if (fabs(FLAGS_rovioli_image_resize_factor - 1.0) > 1e-6) {
+    int newcols = round(
+        image_measurement->image.cols * FLAGS_rovioli_image_resize_factor);
+    int newrows = round(
+        image_measurement->image.rows * FLAGS_rovioli_image_resize_factor);
+
+    cv::resize(
+        image_measurement->image, image_measurement->image,
+        cv::Size(newcols, newrows));
+  }
 
   image_measurement->timestamp =
       rosTimeToNanoseconds(image_message->header.stamp);

--- a/applications/rovioli/src/rovio-flow.cc
+++ b/applications/rovioli/src/rovio-flow.cc
@@ -69,9 +69,8 @@ RovioFlow::RovioFlow(
     const int maplab_camera_idx = std::stoi(camera_id_str);
     CHECK_GE(maplab_camera_idx, 0);
     CHECK_LT(maplab_camera_idx, static_cast<int>(num_cameras));
-    CHECK(
-        maplab_to_rovio_cam_indices_mapping_.insert(
-            maplab_camera_idx, rovio_camera_index))
+    CHECK(maplab_to_rovio_cam_indices_mapping_.insert(
+        maplab_camera_idx, rovio_camera_index))
         << "--rovio_active_camera_indices contains duplicates.";
 
     active_cameras.emplace_back(
@@ -190,10 +189,8 @@ void RovioFlow::attachToMessageFlow(message_flow::MessageFlow* flow) {
   publish_rovio_estimates_ =
       flow->registerPublisher<message_flow_topics::ROVIO_ESTIMATES>();
   CHECK(rovio_interface_);
-  rovio_interface_->registerStateUpdateCallback(
-      std::bind(
-          &RovioFlow::processAndPublishRovioUpdate, this,
-          std::placeholders::_1));
+  rovio_interface_->registerStateUpdateCallback(std::bind(
+      &RovioFlow::processAndPublishRovioUpdate, this, std::placeholders::_1));
 }
 
 void RovioFlow::processAndPublishRovioUpdate(const rovio::RovioState& state) {
@@ -244,10 +241,9 @@ void RovioFlow::processAndPublishRovioUpdate(const rovio::RovioState& state) {
         state.get_qCM(rovio_cam_idx).inverted().toImplementation(),
         state.get_MrMC(rovio_cam_idx));
     common::ensurePositiveQuaternion(&T_B_C.getRotation());
-    CHECK(
-        rovio_estimate->maplab_camera_index_to_T_C_B
-            .emplace(*maplab_cam_idx, T_B_C.inverse())
-            .second);
+    CHECK(rovio_estimate->maplab_camera_index_to_T_C_B
+              .emplace(*maplab_cam_idx, T_B_C.inverse())
+              .second);
   }
 
   // Optional localizations.


### PR DESCRIPTION
Added flags to enable resizing the input images for rovioli and maplab node. The image resize is carried over to the saved sensor config when map building.

Depends on this tiny PR in aslam_cv [#54](https://github.com/ethz-asl/aslam_cv2/pull/54)