### PR TITLE
Fix dependency issue libv4l-dev

### DIFF
--- a/docs/pages/installation/A_Installation-Ubuntu.md
+++ b/docs/pages/installation/A_Installation-Ubuntu.md
@@ -29,7 +29,7 @@ sudo apt install ros-$ROS_VERSION-desktop-full "ros-$ROS_VERSION-tf2-*" "ros-$RO
 
 
 # Install framework dependencies.
-sudo apt install autotools-dev ccache doxygen dh-autoreconf git liblapack-dev libblas-dev libgtest-dev libreadline-dev libssh2-1-dev pylint clang-format-3.9 python-autopep8 python-catkin-tools python-pip python-git python-setuptools python-termcolor python-wstool libatlas3-base --yes
+sudo apt install autotools-dev ccache doxygen dh-autoreconf git liblapack-dev libblas-dev libgtest-dev libreadline-dev libssh2-1-dev pylint clang-format-3.9 python-autopep8 python-catkin-tools python-pip python-git python-setuptools python-termcolor python-wstool libatlas3-base libv4l-dev --yes
 
 sudo pip install requests
 ```


### PR DESCRIPTION
Bug description:
When installing maplab with the provided commands in the new [wiki](https://maplab.asl.ethz.ch/docs/fix/install-noetic/pages/installation/A_Installation-Ubuntu.html) The build fails with the headerfile libv4l2.h missing.

Recreate:
Build maplab without libv4l-dev installed, following the tutorial on the new wiki.

Fix:
Add libv4l-dev as a installation dependency. This fix should also be added to the installation script. Unfortunately I could not locate it in the repo.
