### PR TITLE
Fix misplaced paranthesis

### DIFF
--- a/applications/maplab-node/src/datasource-rostopic.cc
+++ b/applications/maplab-node/src/datasource-rostopic.cc
@@ -1,13 +1,12 @@
 #include "maplab-node/datasource-rostopic.h"
 
-#include <string>
-
 #include <aslam/common/time.h>
 #include <boost/bind.hpp>
 #include <map-resources/resource-conversion.h>
 #include <maplab-common/accessors.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensors/lidar.h>
+#include <string>
 #include <vi-map/sensor-utils.h>
 #include <vio-common/rostopic-settings.h>
 
@@ -349,21 +348,21 @@ void DataSourceRostopic::odometryEstimateCallback(
         return;
       }
     }
-
-    // This odometry measurement was accepted.
-    last_odometry_timestamp_ns_ = timestamp_ns;
-
-    // Convert message.
-    const vi_map::Odometry6DoF& sensor =
-        sensor_manager_.getSensor<vi_map::Odometry6DoF>(sensor_id);
-    const aslam::Transformation& T_B_S =
-        sensor_manager_.getSensor_T_B_S(sensor_id);
-    maplab::OdometryEstimate::Ptr odometry_measurement =
-        convertRosOdometryMsgToOdometryEstimate(msg, T_B_S, sensor);
-    CHECK(odometry_measurement);
-
-    invokeOdometryCallbacks(odometry_measurement);
   }
+
+  // This odometry measurement was accepted.
+  last_odometry_timestamp_ns_ = timestamp_ns;
+
+  // Convert message.
+  const vi_map::Odometry6DoF& sensor =
+      sensor_manager_.getSensor<vi_map::Odometry6DoF>(sensor_id);
+  const aslam::Transformation& T_B_S =
+      sensor_manager_.getSensor_T_B_S(sensor_id);
+  maplab::OdometryEstimate::Ptr odometry_measurement =
+      convertRosOdometryMsgToOdometryEstimate(msg, T_B_S, sensor);
+  CHECK(odometry_measurement);
+
+  invokeOdometryCallbacks(odometry_measurement);
 }
 
 void DataSourceRostopic::absolute6DoFConstraintCallback(


### PR DESCRIPTION
Tiny bug. At the moment the odometry never actually gets past the callback because `last_odometry_timestamp_ns_` always remains invalid from initialization.