### PR TITLE
fix PointCloudXYZL saving bug

### DIFF
--- a/backend/map-resources/include/map-resources/resource-conversion-inl.h
+++ b/backend/map-resources/include/map-resources/resource-conversion-inl.h
@@ -755,10 +755,10 @@ backend::ResourceType getResourceTypeForPointCloud(
     return backend::ResourceType::kPointCloudXYZRGBN;
   } else if (!has_color && !has_normals && has_scalars) {
     return backend::ResourceType::kPointCloudXYZI;
-  } else if (!has_color && !has_normals && !has_scalars) {
-    return backend::ResourceType::kPointCloudXYZ;
   } else if (!has_color && !has_normals && !has_scalars && has_labels) {
     return backend::ResourceType::kPointCloudXYZL;
+  } else if (!has_color && !has_normals && !has_scalars) {
+    return backend::ResourceType::kPointCloudXYZ;
   }
   LOG(FATAL) << "Currently there is no point cloud type implemented as "
              << "resource that has this particular configuration of color("


### PR DESCRIPTION
Bug: PointCloudXYZL is saved as PointCloudXYZ

So far PointCloudXYZL was simply saved as PointCloudXYZ because the condition that checks for the label was never reached since another condition was fulfilled before

Fixed it by flipping the condition order