### PR TITLE
Fixes to make docs compile again

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2062,6 +2062,11 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED = EIGEN_MAKE_ALIGNED_OPERATOR_NEW=""
+PREDEFINED += POINT_CLOUD_REGISTER_POINT_STRUCT=""
+PREDEFINED += MAPLAB_POINTER_TYPEDEFS=""
+PREDEFINED += __atribute__=""
+PREDEFINED += DOXYGEN_SHOULD_SKIP_THIS
+
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/visualization/include/visualization/color.h
+++ b/visualization/include/visualization/color.h
@@ -21,6 +21,7 @@ struct Color {
 
 static constexpr size_t kNumColors = 256u;
 
+#if defined(DOXYGEN_SHOULD_SKIP_THIS)
 static constexpr Color kCommonRed(255u, 0u, 0u);
 static constexpr Color kCommonBlue(0u, 0u, 255u);
 static constexpr Color kCommonDarkBlue(0u, 0u, 155u);
@@ -47,6 +48,7 @@ static const cv::Scalar kCvCyan(255.0, 255.0, 0.0);
 static const cv::Scalar kCvYellow(0.0, 255.0, 255.0);
 static const cv::Scalar kCvWhite(255.0, 255.0, 255.0);
 static const cv::Scalar kCvBlack(0.0, 0.0, 0.0);
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 inline void convertStringToColor(
     const std::string& color_string, visualization::Color* color) {


### PR DESCRIPTION
The new exhale has issues with expanding some macros, which can be fixed by [predefining](https://exhale.readthedocs.io/en/latest/mastering_doxygen.html#doxygen-predefined) them. 
I'm still not sure why doxygen gets confused by the definitions in `visualization/include/visualization/color.h`
Depends on [aslam_cv2/#58](https://github.com/ethz-asl/aslam_cv2/pull/58).

This fix would need to be merged into all branches for which the documentation is built (all branches for which conf.py exists), right now:
* fix/install-noetic
* fix/empty_pointclouds
* feature/xyzirt_support
* feature/semantic-landmarks
* feature/per_robot_dense_map_publisher
* feature/new_server_approach
* feature/map_publish_timer
* feature/lpm
* feature/loam_matching
* feature/lidar_features_compelete_pipeline
* feature/lidar_features_bundle_adjustment
* devel/turtlebot
* devel/euroc_launch
* devel/dostreif
* devel/bosch
* devel/alice

As an alternative, we could also define a whitelist for which branches we want to build the doc.
