### PR TITLE
Fix/empty pointclouds

### DIFF
--- a/backend/map-resources/include/map-resources/resource-conversion-inl.h
+++ b/backend/map-resources/include/map-resources/resource-conversion-inl.h
@@ -228,7 +228,6 @@ void resizePointCloud(
     const bool /*has_normals*/, const bool /*has_scalar*/,
     const bool /*has_labels*/, pcl::PointCloud<PointType>* point_cloud) {
   CHECK_NOTNULL(point_cloud);
-  CHECK_GT(num_points, 0u);
   point_cloud->points.resize(num_points);
 }
 


### PR DESCRIPTION
this fixes a crash that appeared if submaps without pointclouds are received in the beginning of a run. In this case the checks for empty pointclouds would kick in and maplab would crash. This fix handles this scenario softly by just putting a warning and not publishing a pointcloud