### PR TITLE
draco compressed pointcloud import/export

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -103,3 +103,6 @@
 [submodule "dependencies/3rdparty/libpointmatcher"]
 	path = dependencies/3rdparty/libpointmatcher
 	url = git@github.com:ANYbotics/libpointmatcher.git
+[submodule "dependencies/3rdparty/draco"]
+	path = dependencies/3rdparty/draco
+	url = git@github.com:leggedrobotics/draco.git

--- a/algorithms/dense-reconstruction/stereo-dense-reconstruction/test/test-stereo-dense-reconstruction.cpp
+++ b/algorithms/dense-reconstruction/stereo-dense-reconstruction/test/test-stereo-dense-reconstruction.cpp
@@ -304,7 +304,7 @@ class StereoDenseReconstructionTest : public ::testing::Test {
 
     const std::string mesh_file_name =
         kTestDataBaseFolder + name +
-        backend::ResourceTypeFileSuffix[static_cast<int>(
+        backend::getResourceTypesFileSuffixes()[static_cast<int>(
             backend::ResourceType::kPointCloudXYZRGBN)];
     if (common::fileExists(mesh_file_name)) {
       common::deleteFile(mesh_file_name);
@@ -312,7 +312,7 @@ class StereoDenseReconstructionTest : public ::testing::Test {
 
     const std::string depth_map_file_name =
         kTestDataBaseFolder + name +
-        backend::ResourceTypeFileSuffix[static_cast<int>(
+        backend::getResourceTypesFileSuffixes()[static_cast<int>(
             backend::ResourceType::kRawDepthMap)];
     if (common::fileExists(depth_map_file_name)) {
       common::deleteFile(depth_map_file_name);

--- a/backend/map-resources/include/map-resources/resource-common.h
+++ b/backend/map-resources/include/map-resources/resource-common.h
@@ -12,6 +12,7 @@
 #include <boost/variant.hpp>
 #include <opencv2/core.hpp>
 #include <resources-common/point-cloud.h>
+#include <resources-common/resources-gflags.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <voxblox/core/esdf_map.h>
@@ -62,6 +63,8 @@ enum class ResourceType : int {
 static constexpr size_t kNumResourceTypes =
     static_cast<size_t>(ResourceType::kCount);
 
+bool isResourceTypePointCloud(const ResourceType& type);
+
 // NOTE: [ADD_RESOURCE_TYPE] Add name.
 const std::array<std::string, kNumResourceTypes> ResourceTypeNames = {
     {/*kRawImage*/ "raw_images",
@@ -91,32 +94,7 @@ const std::array<std::string, kNumResourceTypes> ResourceTypeNames = {
      /*kPointCloudXYZL*/ "labeled_point_cloud"}};
 
 // NOTE: [ADD_RESOURCE_TYPE] Add suffix.
-const std::array<std::string, kNumResourceTypes> ResourceTypeFileSuffix = {
-    {/*kRawImage*/ ".pgm",
-     /*kUndistortedImage*/ ".pgm",
-     /*kRectifiedImage*/ ".pgm",
-     /*kImageForDepthMap*/ ".pgm",
-     /*kRawColorImage*/ ".ppm",
-     /*kUndistortedColorImage*/ ".ppm",
-     /*kRectifiedColorImage*/ ".ppm",
-     /*kColorImageForDepthMap*/ ".ppm",
-     /*kRawDepthMap*/ ".pgm",
-     /*kOptimizedDepthMap*/ ".pgm",
-     /*kDisparityMap*/ ".pgm",
-     /*kText*/ ".txt",
-     /*kPmvsReconstructionPath*/ ".txt",
-     /*kTsdfGridPath*/ ".txt",
-     /*kEsdfGridPath*/ ".txt",
-     /*kOccupancyGridPath*/ ".txt",
-     /*kPointCloudXYZ*/ ".ply",
-     /*kPointCloudXYZRGBN*/ ".ply",
-     /*kVoxbloxTsdfMap*/ ".tsdf.voxblox",
-     /*kVoxbloxEsdfMap*/ ".esdf.voxblox",
-     /*kVoxbloxOccupancyMap*/ ".occupancy.voxblox",
-     /*kPointCloudXYZI*/ ".ply",
-     /*kObjectInstanceBoundingBoxes*/ ".obj_instance_bboxes.proto",
-     /*kObjectInstanceMasks*/ ".obj_instance_mask.ppm",
-     /*kPointCloudXYZL*/ ".ply"}};
+std::array<std::string, kNumResourceTypes> getResourceTypesFileSuffixes();
 
 struct ResourceTypeHash {
   template <typename T>

--- a/backend/map-resources/include/map-resources/resource-loader.h
+++ b/backend/map-resources/include/map-resources/resource-loader.h
@@ -10,7 +10,8 @@ namespace backend {
 
 class ResourceLoader {
  public:
-  ResourceLoader() {}
+  ResourceLoader()
+      : resource_types_file_suffixes_(getResourceTypesFileSuffixes()) {}
 
   void migrateResource(
       const ResourceId& id, const ResourceType& type,
@@ -58,6 +59,13 @@ class ResourceLoader {
       const ResourceId& id, const ResourceType& type, const std::string& folder,
       std::string* file_path) const;
 
+  void getPointCloudResourceFilePath(
+      const ResourceId& id, const ResourceType& type, const std::string& folder,
+      const bool compressed, std::string* file_path) const;
+
+  void getResourceTypeFileSuffix(
+      const ResourceType& type, std::string* file_suffix);
+
   void deleteResourceFile(
       const ResourceId& id, const ResourceType& type,
       const std::string& folder);
@@ -76,7 +84,14 @@ class ResourceLoader {
 
  private:
   mutable ResourceCache cache_;
+  const std::array<std::string, backend::kNumResourceTypes>
+      resource_types_file_suffixes_;
 };
+
+template <>
+void ResourceLoader::getResource(
+    const ResourceId& id, const ResourceType& type, const std::string& folder,
+    resources::PointCloud* resource) const;
 
 // Implementation for cv::Mat resources.
 template <>

--- a/backend/map-resources/src/resource-common.cc
+++ b/backend/map-resources/src/resource-common.cc
@@ -7,6 +7,62 @@
 
 namespace backend {
 
+std::array<std::string, kNumResourceTypes> getResourceTypesFileSuffixes() {
+  return std::array<std::string, kNumResourceTypes>{
+      /*kRawImage*/ ".pgm",
+      /*kUndistortedImage*/ ".pgm",
+      /*kRectifiedImage*/ ".pgm",
+      /*kImageForDepthMap*/ ".pgm",
+      /*kRawColorImage*/ ".ppm",
+      /*kUndistortedColorImage*/ ".ppm",
+      /*kRectifiedColorImage*/ ".ppm",
+      /*kColorImageForDepthMap*/ ".ppm",
+      /*kRawDepthMap*/ ".pgm",
+      /*kOptimizedDepthMap*/ ".pgm",
+      /*kDisparityMap*/ ".pgm",
+      /*kText*/ ".txt",
+      /*kPmvsReconstructionPath*/ ".txt",
+      /*kTsdfGridPath*/ ".txt",
+      /*kEsdfGridPath*/ ".txt",
+      /*kOccupancyGridPath*/ ".txt",
+      /*kPointCloudXYZ*/
+      (FLAGS_resources_compress_pointclouds == true)
+          ? resources::kCompressedPointCloudSuffix
+          : resources::kPointCloudSuffix,
+      /*kPointCloudXYZRGBN*/
+      (FLAGS_resources_compress_pointclouds == true)
+          ? resources::kCompressedPointCloudSuffix
+          : resources::kPointCloudSuffix,
+      /*kVoxbloxTsdfMap*/ ".tsdf.voxblox",
+      /*kVoxbloxEsdfMap*/ ".esdf.voxblox",
+      /*kVoxbloxOccupancyMap*/ ".occupancy.voxblox",
+      /*kPointCloudXYZI*/
+      (FLAGS_resources_compress_pointclouds == true)
+          ? resources::kCompressedPointCloudSuffix
+          : resources::kPointCloudSuffix,
+      /*kObjectInstanceBoundingBoxes*/ ".obj_instance_bboxes.proto",
+      /*kObjectInstanceMasks*/ ".obj_instance_mask.ppm",
+      /*kPointCloudXYZL*/
+      (FLAGS_resources_compress_pointclouds == true)
+          ? resources::kCompressedPointCloudSuffix
+          : resources::kPointCloudSuffix};
+}
+
+bool isResourceTypePointCloud(const ResourceType& type) {
+  switch (type) {
+    case ResourceType::kPointCloudXYZ:
+      // Fall through intended.
+    case ResourceType::kPointCloudXYZRGBN:
+      // Fall through intended.
+    case ResourceType::kPointCloudXYZI:
+      // Fall through intended.
+    case ResourceType::kPointCloudXYZL:
+      return true;
+    default:
+      return false;
+  }
+}
+
 // NOTE: [ADD_RESOURCE_DATA_TYPE] Implement.
 template <>
 bool isSameResource(const cv::Mat& resource_A, const cv::Mat& resource_B) {

--- a/backend/map-resources/src/resource-loader.cc
+++ b/backend/map-resources/src/resource-loader.cc
@@ -3,11 +3,12 @@
 #include <cstdio>
 #include <fstream>  // NOLINT
 #include <map-resources/resource_object_instance_bbox.pb.h>
+#include <maplab-common/eigen-proto.h>
 #include <maplab-common/file-system-tools.h>
 #include <maplab-common/proto-serialization-helper.h>
-#include <maplab-common/eigen-proto.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
+#include <resources-common/resources-gflags.h>
 #include <voxblox/io/layer_io.h>
 
 namespace backend {
@@ -69,8 +70,17 @@ void ResourceLoader::getResourceFilePath(
   common::concatenateFolderAndFileName(
       folder, ResourceTypeNames[static_cast<size_t>(type)], file_path);
 
-  const std::string filename =
-      id.hexString() + ResourceTypeFileSuffix[static_cast<size_t>(type)];
+  std::string suffix;
+  if ((type == backend::ResourceType::kPointCloudXYZ ||
+       type == backend::ResourceType::kPointCloudXYZRGBN ||
+       type == backend::ResourceType::kPointCloudXYZI ||
+       type == backend::ResourceType::kPointCloudXYZL) &&
+      resources::FLAGS_resources_compress_pointclouds) {
+    suffix = ".drc";
+  } else {
+    suffix = ResourceTypeFileSuffix[static_cast<size_t>(type)];
+  }
+  const std::string filename = id.hexString() + suffix;
   common::concatenateFolderAndFileName(*file_path, filename, file_path);
 }
 

--- a/backend/map-resources/src/resource-loader.cc
+++ b/backend/map-resources/src/resource-loader.cc
@@ -66,7 +66,10 @@ void ResourceLoader::getResource(
     resources::PointCloud* resource) const {
   CHECK(!folder.empty());
   CHECK_NOTNULL(resource);
-  CHECK(isResourceTypePointCloud(type));
+  CHECK(isResourceTypePointCloud(type))
+      << "Failed to load " << ResourceTypeNames[static_cast<size_t>(type)]
+      << " resource with id " << id.hexString() << " since it is not a "
+      << "pointcloud.";
   if (cache_.getResource<resources::PointCloud>(id, type, resource)) {
     return;
   } else {

--- a/backend/map-resources/src/resource-loader.cc
+++ b/backend/map-resources/src/resource-loader.cc
@@ -66,6 +66,7 @@ void ResourceLoader::getResource(
     resources::PointCloud* resource) const {
   CHECK(!folder.empty());
   CHECK_NOTNULL(resource);
+  CHECK(isResourceTypePointCloud(type));
   if (cache_.getResource<resources::PointCloud>(id, type, resource)) {
     return;
   } else {

--- a/backend/map-resources/test/test_resource_loader.cc
+++ b/backend/map-resources/test/test_resource_loader.cc
@@ -1195,12 +1195,12 @@ TEST_F(ResourceLoaderTest, TestPointCloudCompression) {
   FLAGS_resources_compress_pointclouds = true;
   FLAGS_resources_pointcloud_compression_add_indices = true;
   FLAGS_resources_pointcloud_compression_speed = 0;
-  FLAGS_resources_pointcloud_compression_quantization_bits = 31;
+  FLAGS_resources_pointcloud_compression_quantization_bits = 30;
 
-  ResourceLoader loader;
   resources::PointCloud ply_cloud;
   loadPointcloud(
       kTestDataBaseFolder + "pcl_resource_xyz_rgb_normal.ply", &ply_cloud);
+  ResourceLoader loader;
   loader.saveResourceToFile(
       draco_cloud_filename, backend::ResourceType::kPointCloudXYZRGBN,
       ply_cloud);

--- a/backend/map-resources/test/test_resource_loader.cc
+++ b/backend/map-resources/test/test_resource_loader.cc
@@ -1223,6 +1223,7 @@ TEST_F(ResourceLoaderTest, TestPointCloudCompression) {
     EXPECT_NEAR(ply_cloud.colors[idx + 1], draco_cloud.colors[idx + 1], 5e-3);
     EXPECT_NEAR(ply_cloud.colors[idx + 2], draco_cloud.colors[idx + 2], 5e-3);
   }
+  FLAGS_resources_compress_pointclouds = initial_compression_state;
 }
 
 }  // namespace backend

--- a/backend/map-resources/test/test_resource_loader.cc
+++ b/backend/map-resources/test/test_resource_loader.cc
@@ -1182,6 +1182,35 @@ TEST_F(ResourceLoaderTest, TestResourceCache) {
       loader.getCacheStatistic().getNumMiss(ResourceType::kText),
       2u + max_num_cache_entries_per_type + 2u);
 }
+TEST_F(ResourceLoaderTest, TestPointCloudCompression) {
+  constexpr bool kIsMapFolder = false;
+  createResourceTemplates(
+      "TestPointCloudCompression", kTestMapFolderA, kIsMapFolder, &templates_);
+  const std::string draco_cloud_filename =
+      kTestDataBaseFolder + "TestPointCloudCompression/compressed_cloud.drc";
+  if (common::fileExists(draco_cloud_filename)) {
+    common::deleteFile(draco_cloud_filename);
+  }
+  const bool initial_compression_state = FLAGS_resources_compress_pointclouds;
+  FLAGS_resources_compress_pointclouds = true;
+  FLAGS_resources_pointcloud_compression_add_indices = true;
+  FLAGS_resources_pointcloud_compression_speed = 0;
+  FLAGS_resources_pointcloud_compression_quantization_bits = 31;
+
+  ResourceLoader loader;
+  resources::PointCloud ply_cloud;
+  loadPointcloud(
+      kTestDataBaseFolder + "pcl_resource_xyz_rgb_normal.ply", &ply_cloud);
+  loader.saveResourceToFile(
+      draco_cloud_filename, backend::ResourceType::kPointCloudXYZRGBN,
+      ply_cloud);
+  resources::PointCloud draco_cloud;
+  loader.loadResourceFromFile(
+      draco_cloud_filename, backend::ResourceType::kPointCloudXYZRGBN,
+      &draco_cloud);
+
+  EXPECT_EQ(ply_cloud.size(), draco_cloud.size());
+}
 
 }  // namespace backend
 

--- a/backend/map-resources/test/test_resource_loader.cc
+++ b/backend/map-resources/test/test_resource_loader.cc
@@ -1208,8 +1208,21 @@ TEST_F(ResourceLoaderTest, TestPointCloudCompression) {
   loader.loadResourceFromFile(
       draco_cloud_filename, backend::ResourceType::kPointCloudXYZRGBN,
       &draco_cloud);
-
+  if (common::fileExists(draco_cloud_filename)) {
+    common::deleteFile(draco_cloud_filename);
+  }
   EXPECT_EQ(ply_cloud.size(), draco_cloud.size());
+  for (size_t idx = 0u; idx < ply_cloud.size(); idx++) {
+    EXPECT_NEAR(ply_cloud.xyz[idx], draco_cloud.xyz[idx], 5e-3);
+    EXPECT_NEAR(ply_cloud.xyz[idx + 1], draco_cloud.xyz[idx + 1], 5e-3);
+    EXPECT_NEAR(ply_cloud.xyz[idx + 2], draco_cloud.xyz[idx + 2], 5e-3);
+    EXPECT_NEAR(ply_cloud.normals[idx], draco_cloud.normals[idx], 5e-3);
+    EXPECT_NEAR(ply_cloud.normals[idx + 1], draco_cloud.normals[idx + 1], 5e-3);
+    EXPECT_NEAR(ply_cloud.normals[idx + 2], draco_cloud.normals[idx + 2], 5e-3);
+    EXPECT_NEAR(ply_cloud.colors[idx], draco_cloud.colors[idx], 5e-3);
+    EXPECT_NEAR(ply_cloud.colors[idx + 1], draco_cloud.colors[idx + 1], 5e-3);
+    EXPECT_NEAR(ply_cloud.colors[idx + 2], draco_cloud.colors[idx + 2], 5e-3);
+  }
 }
 
 }  // namespace backend

--- a/common/resources-common/CMakeLists.txt
+++ b/common/resources-common/CMakeLists.txt
@@ -18,7 +18,10 @@ include_directories(include
 
 link_directories(${draco_LIBRARY_DIR})
 
-cs_add_library(libtinyply  src/tinyply/tinyply.cc)
+cs_add_library(libtinyply
+  src/tinyply/tinyply.cc)
+cs_add_library(${PROJECT_NAME}
+  src/resources-gflags.cc)
 ############
 ## EXPORT ##
 ############

--- a/common/resources-common/CMakeLists.txt
+++ b/common/resources-common/CMakeLists.txt
@@ -1,27 +1,18 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(resources_common)
-
-find_package(catkin_simple)
+find_package(catkin_simple REQUIRED)
 catkin_simple(REQUIRED)
 find_package(Draco REQUIRED)
 #############
 # LIBRARIES #
 #############
-catkin_package(
-  INCLUDE_DIRS include ${draco_INCLUDE_DIR}
-  LIBRARIES ${PROJECT_NAME} ${draco_LIBRARY_DIR}
-)
-include_directories(include
-        ${catkin_INCLUDE_DIRS}
-        ${draco_INCLUDE_DIR}/..
-        ${draco_INCLUDE_DIR})
-
 link_directories(${draco_LIBRARY_DIR})
-
 cs_add_library(libtinyply
   src/tinyply/tinyply.cc)
 cs_add_library(${PROJECT_NAME}
-  src/resources-gflags.cc)
+  src/resources-gflags.cc
+  src/point-cloud.cc)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} libdraco.so)
 ############
 ## EXPORT ##
 ############

--- a/common/resources-common/CMakeLists.txt
+++ b/common/resources-common/CMakeLists.txt
@@ -1,15 +1,24 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(resources_common)
 
-find_package(catkin_simple REQUIRED)
-catkin_simple(ALL_DEPS_REQUIRED)
-
+find_package(catkin_simple)
+catkin_simple(REQUIRED)
+find_package(Draco REQUIRED)
 #############
 # LIBRARIES #
 #############
+catkin_package(
+  INCLUDE_DIRS include ${draco_INCLUDE_DIR}
+  LIBRARIES ${PROJECT_NAME} ${draco_LIBRARY_DIR}
+)
+include_directories(include
+        ${catkin_INCLUDE_DIRS}
+        ${draco_INCLUDE_DIR}/..
+        ${draco_INCLUDE_DIR})
+
+link_directories(${draco_LIBRARY_DIR})
+
 cs_add_library(libtinyply  src/tinyply/tinyply.cc)
-
-
 ############
 ## EXPORT ##
 ############

--- a/common/resources-common/include/resources-common/point-cloud.h
+++ b/common/resources-common/include/resources-common/point-cloud.h
@@ -10,10 +10,6 @@
 
 #include <Eigen/Core>
 #include <aslam/common/pose-types.h>
-#include <draco/compression/encode.h>
-#include <draco/io/file_utils.h>
-#include <draco/io/point_cloud_io.h>
-#include <draco/point_cloud/point_cloud_builder.h>
 #include <maplab-common/file-system-tools.h>
 #include <maplab-common/parallel-process.h>
 #include <maplab-common/threading-helpers.h>
@@ -268,6 +264,8 @@ struct PointCloud {
     return is_same;
   }
 
+  void writeToFileCompressed(const std::string& file_path) const;
+
   inline void writeToFile(const std::string& file_path) const {
     CHECK(common::createPathToFile(file_path));
 
@@ -313,74 +311,6 @@ struct PointCloud {
     filebuf.close();
   }
 
-  inline void writeToFileCompressed(const std::string& file_path) const {
-    CHECK(common::createPathToFile(file_path));
-    draco::PointCloudBuilder builder;
-    builder.Start(size());
-    int position_att_id = builder.AddAttribute(
-        draco::GeometryAttribute::POSITION, 3, draco::DT_FLOAT32);
-    builder.SetAttributeValuesForAllPoints(position_att_id, xyz.data(), 0);
-
-    if (!normals.empty()) {
-      int normals_att_id = builder.AddAttribute(
-          draco::GeometryAttribute::NORMAL, 3, draco::DT_FLOAT32);
-      builder.SetAttributeValuesForAllPoints(normals_att_id, normals.data(), 0);
-    }
-    if (!colors.empty()) {
-      int colors_att_id = builder.AddAttribute(
-          draco::GeometryAttribute::COLOR, 3, draco::DT_UINT8);
-      builder.SetAttributeValuesForAllPoints(colors_att_id, colors.data(), 0);
-    }
-    int scalars_att_id;
-    if (!scalars.empty()) {
-      scalars_att_id = builder.AddAttribute(
-          draco::GeometryAttribute::GENERIC, 1, draco::DT_FLOAT32);
-      builder.SetAttributeValuesForAllPoints(scalars_att_id, scalars.data(), 0);
-    }
-    int labels_att_id;
-    if (!labels.empty()) {
-      labels_att_id = builder.AddAttribute(
-          draco::GeometryAttribute::GENERIC, 1, draco::DT_UINT32);
-      builder.SetAttributeValuesForAllPoints(labels_att_id, labels.data(), 0);
-    }
-
-    std::unique_ptr<draco::PointCloud> draco_pointcloud =
-        builder.Finalize(false);
-    CHECK_NOTNULL(draco_pointcloud);
-    if (!scalars.empty()) {
-      std::unique_ptr<draco::AttributeMetadata> scalars_metadata =
-          std::unique_ptr<draco::AttributeMetadata>(
-              new draco::AttributeMetadata());
-      scalars_metadata->AddEntryString("name", "scalars");
-      draco_pointcloud->AddAttributeMetadata(
-          scalars_att_id, std::move(scalars_metadata));
-    }
-    if (!labels.empty()) {
-      std::unique_ptr<draco::AttributeMetadata> labels_metadata =
-          std::unique_ptr<draco::AttributeMetadata>(
-              new draco::AttributeMetadata());
-      labels_metadata->AddEntryString("name", "labels");
-      draco_pointcloud->AddAttributeMetadata(
-          labels_att_id, std::move(labels_metadata));
-    }
-    std::filebuf filebuf;
-    filebuf.open(file_path, std::ios::out | std::ios::binary);
-    CHECK(filebuf.is_open());
-    std::ostream output_stream(&filebuf);
-    draco::PointCloudEncodingMethod method =
-        draco::POINT_CLOUD_KD_TREE_ENCODING;
-    draco::EncoderOptions options =
-        draco::EncoderOptions::CreateDefaultOptions();
-    options.SetSpeed(
-        FLAGS_resources_pointcloud_compression_speed,
-        FLAGS_resources_pointcloud_compression_speed);
-    options.SetGlobalInt(
-        "quantization_bits",
-        FLAGS_resources_pointcloud_compression_quantization_bits);
-    draco::WritePointCloudIntoStream(
-        draco_pointcloud.get(), output_stream, method, options);
-  }
-
   inline bool loadFromFile(const std::string& file_path) {
     if (!common::fileExists(file_path)) {
       VLOG(1) << "Point cloud file does not exist! Path: " << file_path;
@@ -390,118 +320,7 @@ struct PointCloud {
     CHECK_GT(file_path.size(), 4u);
 
     if (file_path.substr(file_path.size() - 4u) == ".drc") {
-      std::ifstream input_file(file_path, std::ios::binary);
-      if (!input_file) {
-        LOG(ERROR) << "Failed opening the input file.";
-        return false;
-      }
-
-      // Read the file stream into a buffer.
-      std::streampos file_size = 0;
-      input_file.seekg(0, std::ios::end);
-      file_size = input_file.tellg() - file_size;
-      input_file.seekg(0, std::ios::beg);
-      std::vector<char> data(file_size);
-      input_file.read(data.data(), file_size);
-
-      if (data.empty()) {
-        LOG(ERROR) << "Empty input file.";
-        return false;
-      }
-
-      draco::DecoderBuffer buffer;
-      buffer.Init(data.data(), data.size());
-
-      std::unique_ptr<draco::PointCloud> pc;
-
-      auto type_statusor = draco::Decoder::GetEncodedGeometryType(&buffer);
-      if (!type_statusor.ok()) {
-        LOG(ERROR) << "Draco geometry type is unknown.";
-        return false;
-      }
-      const draco::EncodedGeometryType geom_type = type_statusor.value();
-      if (geom_type != draco::POINT_CLOUD) {
-        LOG(ERROR) << "Draco Geometry Type " << geom_type
-                   << " is not supported";
-        return false;
-      }
-
-      draco::Decoder decoder;
-      auto statusor = decoder.DecodePointCloudFromBuffer(&buffer);
-      if (!statusor.ok()) {
-        LOG(ERROR) << "Draco decoding failed.";
-        return false;
-      }
-      pc = std::move(statusor).value();
-      CHECK_NOTNULL(pc);
-
-      int32_t number_of_attributes = pc->num_attributes();
-
-      draco::PointIndex::ValueType number_of_points = pc->num_points();
-      // for each attribute
-      for (uint32_t att_id = 0; att_id < number_of_attributes; att_id++) {
-        const draco::PointAttribute* attribute = pc->attribute(att_id);
-
-        if (!attribute->IsValid()) {
-          LOG(ERROR) << "Attribute of Draco pointcloud is not valid!";
-          continue;
-        }
-
-        if (attribute->attribute_type() == draco::GeometryAttribute::POSITION) {
-          xyz.resize(3 * number_of_points);
-          for (draco::PointIndex::ValueType point_index = 0;
-               point_index < number_of_points; point_index++) {
-            float* out_data = &xyz[3 * point_index];
-            CHECK_NOTNULL(out_data);
-            attribute->GetValue(
-                draco::AttributeValueIndex(point_index), out_data);
-          }
-        } else if (
-            attribute->attribute_type() == draco::GeometryAttribute::NORMAL) {
-          normals.resize(3 * number_of_points);
-          for (draco::PointIndex::ValueType point_index = 0;
-               point_index < number_of_points; point_index++) {
-            float* out_data = &normals[3 * point_index];
-            CHECK_NOTNULL(out_data);
-            attribute->GetValue(
-                draco::AttributeValueIndex(point_index), out_data);
-          }
-        } else if (
-            attribute->attribute_type() == draco::GeometryAttribute::COLOR) {
-          colors.resize(3 * number_of_points);
-          for (draco::PointIndex::ValueType point_index = 0;
-               point_index < number_of_points; point_index++) {
-            unsigned char* out_data = &colors[3 * point_index];
-            CHECK_NOTNULL(out_data);
-            attribute->GetValue(
-                draco::AttributeValueIndex(point_index), out_data);
-          }
-        } else {
-          auto metadata = pc->GetAttributeMetadataByAttributeId(att_id);
-          CHECK_NOTNULL(metadata);
-          std::string attribute_name;
-          metadata->GetEntryString("name", &attribute_name);
-          if (attribute_name == "scalars") {
-            scalars.resize(number_of_points);
-            for (draco::PointIndex::ValueType point_index = 0;
-                 point_index < number_of_points; point_index++) {
-              float* out_data = &scalars[point_index];
-              CHECK_NOTNULL(out_data);
-              attribute->GetValue(
-                  draco::AttributeValueIndex(point_index), out_data);
-            }
-          } else if (attribute_name == "labels") {
-            labels.resize(number_of_points);
-            for (draco::PointIndex::ValueType point_index = 0;
-                 point_index < number_of_points; point_index++) {
-              uint32_t* out_data = &labels[point_index];
-              CHECK_NOTNULL(out_data);
-              attribute->GetValue(
-                  draco::AttributeValueIndex(point_index), out_data);
-            }
-          }
-        }
-      }
+      return loadFromCompressedFile(file_path);
     } else {
       std::ifstream stream_ply(file_path);
       if (stream_ply.is_open()) {
@@ -546,6 +365,8 @@ struct PointCloud {
       return false;
     }
   }
+
+  bool loadFromCompressedFile(const std::string& file_path);
 
   inline bool colorizePointCloud(
       const size_t start_point_idx, const size_t end_point_idx, const uint8_t r,

--- a/common/resources-common/include/resources-common/point-cloud.h
+++ b/common/resources-common/include/resources-common/point-cloud.h
@@ -21,6 +21,9 @@ namespace resources {
 
 typedef Eigen::Matrix<uint8_t, 4, 1> RgbaColor;
 
+static const std::string kPointCloudSuffix = ".ply";
+static const std::string kCompressedPointCloudSuffix = ".drc";
+
 struct PointCloud {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -316,10 +319,9 @@ struct PointCloud {
       VLOG(1) << "Point cloud file does not exist! Path: " << file_path;
       return false;
     }
-
-    CHECK_GT(file_path.size(), 4u);
-
-    if (file_path.substr(file_path.size() - 4u) == ".drc") {
+    CHECK_GE(file_path.size(), 4);
+    const std::string suffix = file_path.substr(file_path.size() - 4);
+    if (suffix == kCompressedPointCloudSuffix) {
       return loadFromCompressedFile(file_path);
     } else {
       std::ifstream stream_ply(file_path);

--- a/common/resources-common/include/resources-common/resources-gflags.h
+++ b/common/resources-common/include/resources-common/resources-gflags.h
@@ -4,12 +4,9 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
-namespace resources {
-
 // Point cloud compression.
 DECLARE_bool(resources_compress_pointclouds);
 DECLARE_int32(resources_pointcloud_compression_speed);
 DECLARE_int32(resources_pointcloud_compression_quantization_bits);
-}  // namespace resources
 
 #endif  // RESOURCES_COMMON_RESOURCES_GFLAGS_H_

--- a/common/resources-common/include/resources-common/resources-gflags.h
+++ b/common/resources-common/include/resources-common/resources-gflags.h
@@ -6,6 +6,7 @@
 
 // Point cloud compression.
 DECLARE_bool(resources_compress_pointclouds);
+DECLARE_bool(resources_pointcloud_compression_add_indices);
 DECLARE_int32(resources_pointcloud_compression_speed);
 DECLARE_int32(resources_pointcloud_compression_quantization_bits);
 

--- a/common/resources-common/include/resources-common/resources-gflags.h
+++ b/common/resources-common/include/resources-common/resources-gflags.h
@@ -1,0 +1,15 @@
+#ifndef RESOURCES_COMMON_RESOURCES_GFLAGS_H_
+#define RESOURCES_COMMON_RESOURCES_GFLAGS_H_
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+namespace resources {
+
+// Point cloud compression.
+DECLARE_bool(resources_compress_pointclouds);
+DECLARE_int32(resources_pointcloud_compression_speed);
+DECLARE_int32(resources_pointcloud_compression_quantization_bits);
+}  // namespace resources
+
+#endif  // RESOURCES_COMMON_RESOURCES_GFLAGS_H_

--- a/common/resources-common/package.xml
+++ b/common/resources-common/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>aslam_cv_common</depend>
+  <depend>draco</depend>
   <depend>eigen_catkin</depend>
   <depend>gflags_catkin</depend>
   <depend>glog_catkin</depend>

--- a/common/resources-common/src/point-cloud.cc
+++ b/common/resources-common/src/point-cloud.cc
@@ -1,5 +1,7 @@
 #include "resources-common/point-cloud.h"
 
+#include <numeric>
+
 #include <draco/compression/encode.h>
 #include <draco/io/file_utils.h>
 #include <draco/io/point_cloud_io.h>
@@ -14,17 +16,18 @@ void PointCloud::writeToFileCompressed(const std::string& file_path) const {
   CHECK_GE(31, FLAGS_resources_pointcloud_compression_quantization_bits);
   draco::PointCloudBuilder builder;
   builder.Start(size());
-  int position_att_id = builder.AddAttribute(
+
+  const int position_att_id = builder.AddAttribute(
       draco::GeometryAttribute::POSITION, 3, draco::DT_FLOAT32);
   builder.SetAttributeValuesForAllPoints(position_att_id, xyz.data(), 0);
 
   if (!normals.empty()) {
-    int normals_att_id = builder.AddAttribute(
+    const int normals_att_id = builder.AddAttribute(
         draco::GeometryAttribute::NORMAL, 3, draco::DT_FLOAT32);
     builder.SetAttributeValuesForAllPoints(normals_att_id, normals.data(), 0);
   }
   if (!colors.empty()) {
-    int colors_att_id = builder.AddAttribute(
+    const int colors_att_id = builder.AddAttribute(
         draco::GeometryAttribute::COLOR, 3, draco::DT_UINT8);
     builder.SetAttributeValuesForAllPoints(colors_att_id, colors.data(), 0);
   }
@@ -41,8 +44,28 @@ void PointCloud::writeToFileCompressed(const std::string& file_path) const {
     builder.SetAttributeValuesForAllPoints(labels_att_id, labels.data(), 0);
   }
 
+  // Draco encoding does not maintain point order.
+  // Save point index in additional field entry.
+  int index_att_id;
+  if (FLAGS_resources_pointcloud_compression_add_indices) {
+    std::vector<uint32_t> indices(size());
+    std::iota(indices.begin(), indices.end(), 0);
+    index_att_id = builder.AddAttribute(
+        draco::GeometryAttribute::GENERIC, 1, draco::DT_UINT32);
+    builder.SetAttributeValuesForAllPoints(index_att_id, indices.data(), 0);
+  }
+
   std::unique_ptr<draco::PointCloud> draco_pointcloud = builder.Finalize(false);
   CHECK_NOTNULL(draco_pointcloud);
+
+  if (FLAGS_resources_pointcloud_compression_add_indices) {
+    std::unique_ptr<draco::AttributeMetadata> index_metadata =
+        std::unique_ptr<draco::AttributeMetadata>(
+            new draco::AttributeMetadata());
+    index_metadata->AddEntryString("name", "index");
+    draco_pointcloud->AddAttributeMetadata(
+        index_att_id, std::move(index_metadata));
+  }
   if (!scalars.empty()) {
     std::unique_ptr<draco::AttributeMetadata> scalars_metadata =
         std::unique_ptr<draco::AttributeMetadata>(
@@ -120,10 +143,30 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
   pc = std::move(statusor).value();
   CHECK_NOTNULL(pc);
 
-  int32_t number_of_attributes = pc->num_attributes();
-
+  LOG(WARNING) << "lolo";
   draco::PointIndex::ValueType number_of_points = pc->num_points();
-  // for each attribute
+  std::vector<uint32_t> indices(number_of_points);
+  int index_attribute_id = pc->GetAttributeIdByMetadataEntry("name", "index");
+  LOG(WARNING) << "huhu";
+  LOG(WARNING) << index_attribute_id;
+  if (index_attribute_id >= 0) {
+    const draco::PointAttribute* index_attribute =
+        pc->attribute(index_attribute_id);
+    CHECK_NOTNULL(index_attribute);
+    for (draco::PointIndex::ValueType point_index = 0;
+         point_index < number_of_points; point_index++) {
+      uint32_t* out_data = &indices[point_index];
+      index_attribute->GetValue(
+          draco::AttributeValueIndex(point_index), out_data);
+      CHECK_GE(number_of_points - 1u, *out_data);
+    }
+    LOG(WARNING) << "lasdf";
+  } else {
+    LOG(WARNING) << "hhugs";
+    std::iota(indices.begin(), indices.end(), 0);
+  }
+  LOG(INFO) << "easy";
+  const int32_t number_of_attributes = pc->num_attributes();
   for (uint32_t att_id = 0; att_id < number_of_attributes; att_id++) {
     const draco::PointAttribute* attribute = pc->attribute(att_id);
 
@@ -136,7 +179,7 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
       xyz.resize(3 * number_of_points);
       for (draco::PointIndex::ValueType point_index = 0;
            point_index < number_of_points; point_index++) {
-        float* out_data = &xyz[3 * point_index];
+        float* out_data = &xyz[3 * indices[point_index]];
         CHECK_NOTNULL(out_data);
         attribute->GetValue(draco::AttributeValueIndex(point_index), out_data);
       }
@@ -145,7 +188,7 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
       normals.resize(3 * number_of_points);
       for (draco::PointIndex::ValueType point_index = 0;
            point_index < number_of_points; point_index++) {
-        float* out_data = &normals[3 * point_index];
+        float* out_data = &normals[3 * indices[point_index]];
         CHECK_NOTNULL(out_data);
         attribute->GetValue(draco::AttributeValueIndex(point_index), out_data);
       }
@@ -153,7 +196,7 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
       colors.resize(3 * number_of_points);
       for (draco::PointIndex::ValueType point_index = 0;
            point_index < number_of_points; point_index++) {
-        unsigned char* out_data = &colors[3 * point_index];
+        unsigned char* out_data = &colors[3 * indices[point_index]];
         CHECK_NOTNULL(out_data);
         attribute->GetValue(draco::AttributeValueIndex(point_index), out_data);
       }
@@ -166,7 +209,7 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
         scalars.resize(number_of_points);
         for (draco::PointIndex::ValueType point_index = 0;
              point_index < number_of_points; point_index++) {
-          float* out_data = &scalars[point_index];
+          float* out_data = &scalars[indices[point_index]];
           CHECK_NOTNULL(out_data);
           attribute->GetValue(
               draco::AttributeValueIndex(point_index), out_data);
@@ -175,7 +218,7 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
         labels.resize(number_of_points);
         for (draco::PointIndex::ValueType point_index = 0;
              point_index < number_of_points; point_index++) {
-          uint32_t* out_data = &labels[point_index];
+          uint32_t* out_data = &labels[indices[point_index]];
           CHECK_NOTNULL(out_data);
           attribute->GetValue(
               draco::AttributeValueIndex(point_index), out_data);

--- a/common/resources-common/src/point-cloud.cc
+++ b/common/resources-common/src/point-cloud.cc
@@ -13,7 +13,7 @@ void PointCloud::writeToFileCompressed(const std::string& file_path) const {
   CHECK_GE(FLAGS_resources_pointcloud_compression_speed, 0);
   CHECK_GE(10, FLAGS_resources_pointcloud_compression_speed);
   CHECK_GE(FLAGS_resources_pointcloud_compression_quantization_bits, 1);
-  CHECK_GE(31, FLAGS_resources_pointcloud_compression_quantization_bits);
+  CHECK_GE(30, FLAGS_resources_pointcloud_compression_quantization_bits);
   draco::PointCloudBuilder builder;
   builder.Start(size());
 

--- a/common/resources-common/src/point-cloud.cc
+++ b/common/resources-common/src/point-cloud.cc
@@ -1,0 +1,202 @@
+#include "resources-common/point-cloud.h"
+
+#include <draco/compression/encode.h>
+#include <draco/io/file_utils.h>
+#include <draco/io/point_cloud_io.h>
+#include <draco/point_cloud/point_cloud_builder.h>
+
+namespace resources {
+
+void PointCloud::writeToFileCompressed(const std::string& file_path) const {
+  CHECK_GE(FLAGS_resources_pointcloud_compression_speed, 0);
+  CHECK_GE(10, FLAGS_resources_pointcloud_compression_speed);
+  CHECK_GE(FLAGS_resources_pointcloud_compression_quantization_bits, 1);
+  CHECK_GE(31, FLAGS_resources_pointcloud_compression_quantization_bits);
+  draco::PointCloudBuilder builder;
+  builder.Start(size());
+  int position_att_id = builder.AddAttribute(
+      draco::GeometryAttribute::POSITION, 3, draco::DT_FLOAT32);
+  builder.SetAttributeValuesForAllPoints(position_att_id, xyz.data(), 0);
+
+  if (!normals.empty()) {
+    int normals_att_id = builder.AddAttribute(
+        draco::GeometryAttribute::NORMAL, 3, draco::DT_FLOAT32);
+    builder.SetAttributeValuesForAllPoints(normals_att_id, normals.data(), 0);
+  }
+  if (!colors.empty()) {
+    int colors_att_id = builder.AddAttribute(
+        draco::GeometryAttribute::COLOR, 3, draco::DT_UINT8);
+    builder.SetAttributeValuesForAllPoints(colors_att_id, colors.data(), 0);
+  }
+  int scalars_att_id;
+  if (!scalars.empty()) {
+    scalars_att_id = builder.AddAttribute(
+        draco::GeometryAttribute::GENERIC, 1, draco::DT_FLOAT32);
+    builder.SetAttributeValuesForAllPoints(scalars_att_id, scalars.data(), 0);
+  }
+  int labels_att_id;
+  if (!labels.empty()) {
+    labels_att_id = builder.AddAttribute(
+        draco::GeometryAttribute::GENERIC, 1, draco::DT_UINT32);
+    builder.SetAttributeValuesForAllPoints(labels_att_id, labels.data(), 0);
+  }
+
+  std::unique_ptr<draco::PointCloud> draco_pointcloud = builder.Finalize(false);
+  CHECK_NOTNULL(draco_pointcloud);
+  if (!scalars.empty()) {
+    std::unique_ptr<draco::AttributeMetadata> scalars_metadata =
+        std::unique_ptr<draco::AttributeMetadata>(
+            new draco::AttributeMetadata());
+    scalars_metadata->AddEntryString("name", "scalars");
+    draco_pointcloud->AddAttributeMetadata(
+        scalars_att_id, std::move(scalars_metadata));
+  }
+  if (!labels.empty()) {
+    std::unique_ptr<draco::AttributeMetadata> labels_metadata =
+        std::unique_ptr<draco::AttributeMetadata>(
+            new draco::AttributeMetadata());
+    labels_metadata->AddEntryString("name", "labels");
+    draco_pointcloud->AddAttributeMetadata(
+        labels_att_id, std::move(labels_metadata));
+  }
+  std::filebuf filebuf;
+  filebuf.open(file_path, std::ios::out | std::ios::binary);
+  CHECK(filebuf.is_open());
+  std::ostream output_stream(&filebuf);
+  draco::PointCloudEncodingMethod method = draco::POINT_CLOUD_KD_TREE_ENCODING;
+  draco::EncoderOptions options = draco::EncoderOptions::CreateDefaultOptions();
+  options.SetSpeed(
+      FLAGS_resources_pointcloud_compression_speed,
+      FLAGS_resources_pointcloud_compression_speed);
+  options.SetGlobalInt(
+      "quantization_bits",
+      FLAGS_resources_pointcloud_compression_quantization_bits);
+  draco::WritePointCloudIntoStream(
+      draco_pointcloud.get(), output_stream, method, options);
+}
+
+bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
+  std::ifstream input_file(file_path, std::ios::binary);
+  if (!input_file) {
+    LOG(ERROR) << "Failed opening the input file.";
+    return false;
+  }
+
+  // Read the file stream into a buffer.
+  std::streampos file_size = 0;
+  input_file.seekg(0, std::ios::end);
+  file_size = input_file.tellg() - file_size;
+  input_file.seekg(0, std::ios::beg);
+  std::vector<char> data(file_size);
+  input_file.read(data.data(), file_size);
+
+  if (data.empty()) {
+    LOG(ERROR) << "Empty input file.";
+    return false;
+  }
+
+  draco::DecoderBuffer buffer;
+  buffer.Init(data.data(), data.size());
+
+  std::unique_ptr<draco::PointCloud> pc;
+
+  auto type_statusor = draco::Decoder::GetEncodedGeometryType(&buffer);
+  if (!type_statusor.ok()) {
+    LOG(ERROR) << "Draco geometry type is unknown.";
+    return false;
+  }
+  const draco::EncodedGeometryType geom_type = type_statusor.value();
+  if (geom_type != draco::POINT_CLOUD) {
+    LOG(ERROR) << "Draco Geometry Type " << geom_type << " is not supported";
+    return false;
+  }
+
+  draco::Decoder decoder;
+  auto statusor = decoder.DecodePointCloudFromBuffer(&buffer);
+  if (!statusor.ok()) {
+    LOG(ERROR) << "Draco decoding failed.";
+    return false;
+  }
+  pc = std::move(statusor).value();
+  CHECK_NOTNULL(pc);
+
+  int32_t number_of_attributes = pc->num_attributes();
+
+  draco::PointIndex::ValueType number_of_points = pc->num_points();
+  // for each attribute
+  for (uint32_t att_id = 0; att_id < number_of_attributes; att_id++) {
+    const draco::PointAttribute* attribute = pc->attribute(att_id);
+
+    if (!attribute->IsValid()) {
+      LOG(ERROR) << "Attribute of Draco pointcloud is not valid!";
+      continue;
+    }
+
+    if (attribute->attribute_type() == draco::GeometryAttribute::POSITION) {
+      xyz.resize(3 * number_of_points);
+      for (draco::PointIndex::ValueType point_index = 0;
+           point_index < number_of_points; point_index++) {
+        float* out_data = &xyz[3 * point_index];
+        CHECK_NOTNULL(out_data);
+        attribute->GetValue(draco::AttributeValueIndex(point_index), out_data);
+      }
+    } else if (
+        attribute->attribute_type() == draco::GeometryAttribute::NORMAL) {
+      normals.resize(3 * number_of_points);
+      for (draco::PointIndex::ValueType point_index = 0;
+           point_index < number_of_points; point_index++) {
+        float* out_data = &normals[3 * point_index];
+        CHECK_NOTNULL(out_data);
+        attribute->GetValue(draco::AttributeValueIndex(point_index), out_data);
+      }
+    } else if (attribute->attribute_type() == draco::GeometryAttribute::COLOR) {
+      colors.resize(3 * number_of_points);
+      for (draco::PointIndex::ValueType point_index = 0;
+           point_index < number_of_points; point_index++) {
+        unsigned char* out_data = &colors[3 * point_index];
+        CHECK_NOTNULL(out_data);
+        attribute->GetValue(draco::AttributeValueIndex(point_index), out_data);
+      }
+    } else {
+      auto metadata = pc->GetAttributeMetadataByAttributeId(att_id);
+      CHECK_NOTNULL(metadata);
+      std::string attribute_name;
+      metadata->GetEntryString("name", &attribute_name);
+      if (attribute_name == "scalars") {
+        scalars.resize(number_of_points);
+        for (draco::PointIndex::ValueType point_index = 0;
+             point_index < number_of_points; point_index++) {
+          float* out_data = &scalars[point_index];
+          CHECK_NOTNULL(out_data);
+          attribute->GetValue(
+              draco::AttributeValueIndex(point_index), out_data);
+        }
+      } else if (attribute_name == "labels") {
+        labels.resize(number_of_points);
+        for (draco::PointIndex::ValueType point_index = 0;
+             point_index < number_of_points; point_index++) {
+          uint32_t* out_data = &labels[point_index];
+          CHECK_NOTNULL(out_data);
+          attribute->GetValue(
+              draco::AttributeValueIndex(point_index), out_data);
+        }
+      }
+    }
+  }
+
+  //  Check pointcloud consistency
+  if (!colors.empty()) {
+    CHECK(hasColor());
+  }
+  if (!normals.empty()) {
+    CHECK(hasNormals());
+  }
+  if (!scalars.empty()) {
+    CHECK(hasScalars());
+  }
+  if (!labels.empty()) {
+    CHECK(hasLabels());
+  }
+  return true;
+}
+}  // namespace resources

--- a/common/resources-common/src/point-cloud.cc
+++ b/common/resources-common/src/point-cloud.cc
@@ -143,12 +143,9 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
   pc = std::move(statusor).value();
   CHECK_NOTNULL(pc);
 
-  LOG(WARNING) << "lolo";
   draco::PointIndex::ValueType number_of_points = pc->num_points();
   std::vector<uint32_t> indices(number_of_points);
   int index_attribute_id = pc->GetAttributeIdByMetadataEntry("name", "index");
-  LOG(WARNING) << "huhu";
-  LOG(WARNING) << index_attribute_id;
   if (index_attribute_id >= 0) {
     const draco::PointAttribute* index_attribute =
         pc->attribute(index_attribute_id);
@@ -160,12 +157,9 @@ bool PointCloud::loadFromCompressedFile(const std::string& file_path) {
           draco::AttributeValueIndex(point_index), out_data);
       CHECK_GE(number_of_points - 1u, *out_data);
     }
-    LOG(WARNING) << "lasdf";
   } else {
-    LOG(WARNING) << "hhugs";
     std::iota(indices.begin(), indices.end(), 0);
   }
-  LOG(INFO) << "easy";
   const int32_t number_of_attributes = pc->num_attributes();
   for (uint32_t att_id = 0; att_id < number_of_attributes; att_id++) {
     const draco::PointAttribute* attribute = pc->attribute(att_id);

--- a/common/resources-common/src/resources-gflags.cc
+++ b/common/resources-common/src/resources-gflags.cc
@@ -1,7 +1,5 @@
 #include "resources-common/resources-gflags.h"
 
-namespace resources {
-
 // Point cloud compression.
 DEFINE_bool(
     resources_compress_pointclouds, false,
@@ -11,4 +9,3 @@ DEFINE_int32(resources_pointcloud_compression_speed, 7, "Draco encoder speed");
 DEFINE_int32(
     resources_pointcloud_compression_quantization_bits, 10,
     "Amount of quantization bits used for draco pointcloud compression.");
-}  // namespace resources

--- a/common/resources-common/src/resources-gflags.cc
+++ b/common/resources-common/src/resources-gflags.cc
@@ -1,0 +1,14 @@
+#include "resources-common/resources-gflags.h"
+
+namespace resources {
+
+// Point cloud compression.
+DEFINE_bool(
+    resources_compress_pointclouds, false,
+    "Defines if pointclouds are"
+    "exported using draco compression.");
+DEFINE_int32(resources_pointcloud_compression_speed, 7, "Draco encoder speed");
+DEFINE_int32(
+    resources_pointcloud_compression_quantization_bits, 10,
+    "Amount of quantization bits used for draco pointcloud compression.");
+}  // namespace resources

--- a/common/resources-common/src/resources-gflags.cc
+++ b/common/resources-common/src/resources-gflags.cc
@@ -5,6 +5,10 @@ DEFINE_bool(
     resources_compress_pointclouds, false,
     "Defines if pointclouds are"
     "exported using draco compression.");
+DEFINE_bool(
+    resources_pointcloud_compression_add_indices, false,
+    "Save additional field with index of point in cloud to be able to "
+    "recover point order when loading file.");
 DEFINE_int32(resources_pointcloud_compression_speed, 7, "Draco encoder speed");
 DEFINE_int32(
     resources_pointcloud_compression_quantization_bits, 10,

--- a/common/resources-common/src/resources-gflags.cc
+++ b/common/resources-common/src/resources-gflags.cc
@@ -9,7 +9,7 @@ DEFINE_bool(
     resources_pointcloud_compression_add_indices, false,
     "Save additional field with index of point in cloud to be able to "
     "recover point order when loading file.");
-DEFINE_int32(resources_pointcloud_compression_speed, 7, "Draco encoder speed");
+DEFINE_int32(resources_pointcloud_compression_speed, 0, "Draco encoder speed");
 DEFINE_int32(
-    resources_pointcloud_compression_quantization_bits, 10,
+    resources_pointcloud_compression_quantization_bits, 13,
     "Amount of quantization bits used for draco pointcloud compression.");

--- a/interfaces/pmvs-interface/src/pmvs-file-utils.cc
+++ b/interfaces/pmvs-interface/src/pmvs-file-utils.cc
@@ -191,9 +191,12 @@ bool exportAllImagesForCalibration(
 
           const int64_t frame_timestamp_ns =
               vertex.getVisualFrame(frame_idx).getTimestampNanoseconds();
-          const std::string file_path =
-              resource_type_folder + std::to_string(frame_timestamp_ns) +
-              backend::ResourceTypeFileSuffix[static_cast<int>(resource_type)];
+          std::string file_suffix;
+          resource_loader.getResourceTypeFileSuffix(
+              resource_type, &file_suffix);
+          const std::string file_path = resource_type_folder +
+                                        std::to_string(frame_timestamp_ns) +
+                                        file_suffix;
 
           resource_loader.saveResourceToFile(
               file_path, resource_type, resource);


### PR DESCRIPTION

this PR allows to save and load pointclouds in a compressed way using draco compression to reduce the file size (reduction up to a factor of 10 while maintaining accuracy of ~3mm)