### PR TITLE
add pointcloud_map sensor to mission

### DIFF
--- a/map-structure/sensors/include/sensors/lidar.h
+++ b/map-structure/sensors/include/sensors/lidar.h
@@ -50,7 +50,7 @@ class Lidar final : public aslam::Sensor {
     return static_cast<std::string>(kLidarIdentifier);
   }
 
-  inline bool hasNumberOfBeans() const {
+  inline bool hasNumberOfBeams() const {
     return has_number_of_beams_;
   }
 
@@ -62,7 +62,7 @@ class Lidar final : public aslam::Sensor {
     return has_lower_fov_angle_;
   }
 
-  inline uint16_t getNumberOfBeans() const {
+  inline uint16_t getNumberOfBeams() const {
     return n_beams_;
   }
 
@@ -74,7 +74,7 @@ class Lidar final : public aslam::Sensor {
     return fov_lower_angle_deg_;
   }
 
-  inline void setNumberOfBeans(const uint16_t n_beams) {
+  inline void setNumberOfBeams(const uint16_t n_beams) {
     n_beams_ = n_beams;
     has_number_of_beams_ = true;
   }

--- a/map-structure/sensors/include/sensors/pointcloud-map-sensor.h
+++ b/map-structure/sensors/include/sensors/pointcloud-map-sensor.h
@@ -51,7 +51,7 @@ class PointCloudMapSensor final : public aslam::Sensor {
     return static_cast<std::string>(kPointCloudMapSensorIdentifier);
   }
 
-  inline bool hasNumberOfBeans() const {
+  inline bool hasNumberOfBeams() const {
     return has_number_of_beams_;
   }
 
@@ -63,7 +63,7 @@ class PointCloudMapSensor final : public aslam::Sensor {
     return has_lower_fov_angle_;
   }
 
-  inline uint16_t getNumberOfBeans() const {
+  inline uint16_t getNumberOfBeams() const {
     return n_beams_;
   }
 
@@ -75,7 +75,7 @@ class PointCloudMapSensor final : public aslam::Sensor {
     return fov_lower_angle_deg_;
   }
 
-  inline void setNumberOfBeans(const uint16_t n_beams) {
+  inline void setNumberOfBeams(const uint16_t n_beams) {
     n_beams_ = n_beams;
     has_number_of_beams_ = true;
   }

--- a/map-structure/vi-map/include/vi-map/vi-map.h
+++ b/map-structure/vi-map/include/vi-map/vi-map.h
@@ -196,6 +196,10 @@ class VIMap : public backend::ResourceMap,
   vi_map::Imu::Ptr getMissionImuPtr(const vi_map::MissionId& id) const;
   const vi_map::Lidar& getMissionLidar(const vi_map::MissionId& id) const;
   vi_map::Lidar::Ptr getMissionLidarPtr(const vi_map::MissionId& id) const;
+  const vi_map::PointCloudMapSensor& getMissionPointCloudMapSensor(
+      const vi_map::MissionId& id) const;
+  vi_map::PointCloudMapSensor::Ptr getMissionPointCloudMapSensorPtr(
+      const vi_map::MissionId& id) const;
   const vi_map::Odometry6DoF& getMissionOdometry6DoFSensor(
       const vi_map::MissionId& id) const;
   vi_map::Odometry6DoF::Ptr getMissionOdometry6DoFSensorPtr(
@@ -725,10 +729,10 @@ class VIMap : public backend::ResourceMap,
       VIMission* mission);
 
   void deleteAllSensorResourcesBeforeTime(
-          const vi_map::MissionId& mission_id, int64_t timestamp_ns,
-          const bool delete_from_file_system);
+      const vi_map::MissionId& mission_id, int64_t timestamp_ns,
+      const bool delete_from_file_system);
   void deleteAllSensorResources(
-          const vi_map::MissionId& mission_id, const bool delete_from_file_system);
+      const vi_map::MissionId& mission_id, const bool delete_from_file_system);
 
   // Map interface (for map manager)
   // ===============================

--- a/map-structure/vi-map/include/vi-map/vi-mission.h
+++ b/map-structure/vi-map/include/vi-map/vi-mission.h
@@ -53,6 +53,7 @@ class VIMission : public Mission {
     is_same &= ncamera_id_ == lhs.ncamera_id_;
     is_same &= imu_id_ == lhs.imu_id_;
     is_same &= lidar_id_ == lhs.lidar_id_;
+    is_same &= pointcloud_map_id_ == lhs.pointcloud_map_id_;
     is_same &= odometry_6dof_id_ == lhs.odometry_6dof_id_;
     is_same &= loop_closure_id_ == lhs.loop_closure_id_;
     is_same &= absolute_6dof_id_ == lhs.absolute_6dof_id_;
@@ -72,6 +73,7 @@ class VIMission : public Mission {
   void setNCameraId(const aslam::SensorId& ncamera_id);
   void setImuId(const aslam::SensorId& imu_id);
   void setLidarId(const aslam::SensorId& lidar_id);
+  void setPointCloudMapId(const aslam::SensorId& pointcloud_map_id);
   void setOdometry6DoFSensor(const aslam::SensorId& odometry_6dof_id);
   void setLoopClosureSensor(const aslam::SensorId& loop_closure_id);
   void setAbsolute6DoFSensor(const aslam::SensorId& absolute_6dof_id);
@@ -83,6 +85,7 @@ class VIMission : public Mission {
   const aslam::SensorId& getNCameraId() const;
   const aslam::SensorId& getImuId() const;
   const aslam::SensorId& getLidarId() const;
+  const aslam::SensorId& getPointCloudMapSensorId() const;
   const aslam::SensorId& getOdometry6DoFSensor() const;
   const aslam::SensorId& getLoopClosureSensor() const;
   const aslam::SensorId& getAbsolute6DoFSensor() const;
@@ -91,6 +94,7 @@ class VIMission : public Mission {
   bool hasNCamera() const;
   bool hasImu() const;
   bool hasLidar() const;
+  bool hasPointCloudMap() const;
   bool hasOdometry6DoFSensor() const;
   bool hasLoopClosureSensor() const;
   bool hasAbsolute6DoFSensor() const;
@@ -196,6 +200,7 @@ class VIMission : public Mission {
   aslam::SensorId ncamera_id_;
   aslam::SensorId imu_id_;
   aslam::SensorId lidar_id_;
+  aslam::SensorId pointcloud_map_id_;
   aslam::SensorId odometry_6dof_id_;
   aslam::SensorId loop_closure_id_;
   aslam::SensorId absolute_6dof_id_;

--- a/map-structure/vi-map/proto/vi-map/vi_map.proto
+++ b/map-structure/vi-map/proto/vi-map/vi_map.proto
@@ -147,6 +147,7 @@ message Mission {
   optional aslam.proto.Id absolute_6dof_id = 13;
   optional aslam.proto.Id detection_id = 14;
   optional aslam.proto.Id wheel_odometry_id = 15;
+  optional aslam.proto.Id pointcloud_map_id = 16;
 }
 
 message MissionBaseframe {

--- a/map-structure/vi-map/src/sensor-manager.cc
+++ b/map-structure/vi-map/src/sensor-manager.cc
@@ -413,7 +413,6 @@ bool SensorManager::deserialize(const YAML::Node& yaml_node) {
         return false;
       }
       CHECK(sensor->isValid());
-
       // Only add the base sensors and buffer the other sensors for later
       // addition to guarantee validity of the sensor manager
       if (base_sensor_ids.count(sensor->getId()) > 0u) {

--- a/map-structure/vi-map/src/vi-mission.cc
+++ b/map-structure/vi-map/src/vi-mission.cc
@@ -24,6 +24,7 @@ VIMission::VIMission(const VIMission& other)
       ncamera_id_(other.ncamera_id_),
       imu_id_(other.imu_id_),
       lidar_id_(other.lidar_id_),
+      pointcloud_map_id_(other.pointcloud_map_id_),
       odometry_6dof_id_(other.odometry_6dof_id_),
       loop_closure_id_(other.loop_closure_id_),
       absolute_6dof_id_(other.absolute_6dof_id_),
@@ -52,6 +53,11 @@ void VIMission::setImuId(const aslam::SensorId& imu_id) {
 void VIMission::setLidarId(const aslam::SensorId& lidar_id) {
   CHECK(lidar_id.isValid());
   lidar_id_ = lidar_id;
+}
+
+void VIMission::setPointCloudMapId(const aslam::SensorId& pointcloud_map_id) {
+  CHECK(pointcloud_map_id.isValid());
+  pointcloud_map_id_ = pointcloud_map_id;
 }
 
 void VIMission::setOdometry6DoFSensor(const aslam::SensorId& odometry_6dof_id) {
@@ -96,6 +102,13 @@ const aslam::SensorId& VIMission::getLidarId() const {
   return lidar_id_;
 }
 
+const aslam::SensorId& VIMission::getPointCloudMapSensorId() const {
+  CHECK(pointcloud_map_id_.isValid())
+      << "There is no valid PointCloudMap ID associated with mission "
+      << mission_id_.shortHex() << "!";
+  return pointcloud_map_id_;
+}
+
 const aslam::SensorId& VIMission::getOdometry6DoFSensor() const {
   CHECK(odometry_6dof_id_.isValid())
       << "There is no valid Odometry 6DoF Sensor ID associated with mission "
@@ -132,6 +145,9 @@ bool VIMission::hasImu() const {
 }
 bool VIMission::hasLidar() const {
   return lidar_id_.isValid();
+}
+bool VIMission::hasPointCloudMap() const {
+  return pointcloud_map_id_.isValid();
 }
 bool VIMission::hasOdometry6DoFSensor() const {
   return odometry_6dof_id_.isValid();
@@ -184,6 +200,9 @@ void VIMission::serialize(vi_map::proto::Mission* proto) const {
   }
   if (lidar_id_.isValid()) {
     lidar_id_.serialize(proto->mutable_lidar_id());
+  }
+  if (pointcloud_map_id_.isValid()) {
+    pointcloud_map_id_.serialize(proto->mutable_pointcloud_map_id());
   }
   if (odometry_6dof_id_.isValid()) {
     odometry_6dof_id_.serialize(proto->mutable_odometry_6dof_id());
@@ -277,6 +296,9 @@ void VIMission::deserialize(
   }
   if (proto.has_lidar_id()) {
     lidar_id_.deserialize(proto.lidar_id());
+  }
+  if (proto.has_pointcloud_map_id()) {
+    pointcloud_map_id_.deserialize(proto.pointcloud_map_id());
   }
   if (proto.has_odometry_6dof_id()) {
     odometry_6dof_id_.deserialize(proto.odometry_6dof_id());


### PR DESCRIPTION
Fixes a crash encountered during testing with multiple robots. When requesting a map lookup the following check crashed: https://github.com/ethz-asl/maplab/blob/devel/alice/map-structure/vi-map/src/sensor-utils.cc#L391
So far the Pointcloud_map sensor was not a member of a mission yet and thus `getSelectedPointCloudMapSensor` was used as a workaround to request the pointcloud map sensor id from the map (instead of the mission).

This PR attached the pointcloud_map sensor id to the mission, such that the sensor id can be requested just as for all other sensors in the mission.
