### PR TITLE
add check if merged map exists requesting read access for it

### DIFF
--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -459,6 +459,12 @@ MaplabServerNode::MapLookupStatus MaplabServerNode::mapLookup(
 
   std::lock_guard<std::mutex> lock(mutex_);
 
+  if (!map_manager_.hasMap(kMergedMapKey)) {
+    LOG(WARNING)
+        << "[MaplabServerNode] Received map lookup but merged map does not "
+           "exist yet!";
+    return MapLookupStatus::kPoseNotAvailableYet;
+  }
   if (robot_name.empty()) {
     LOG(WARNING)
         << "[MaplabServerNode] Received map lookup with empty robot name!";


### PR DESCRIPTION
this check fixes a crash that occured during testing if a maplookup was requested while the first submap is still being processed. In this case the robot_to_mission_id_map_ is already updated (https://github.com/ethz-asl/maplab/blob/fix/early_lookup_crash/applications/maplab-server-node/src/maplab-server-node.cc#L401) but the first submap is not merged yet. Thus, the merged map does not yet exist which will eventually lead to a crash in https://github.com/ethz-asl/maplab/blob/fix/early_lookup_crash/applications/maplab-server-node/src/maplab-server-node.cc#L508. 

with the change in this PR the call will simply return with the information that the pose is not yet available