### PR TITLE
Fixed cam-imu jacobian

### DIFF
--- a/algorithms/ceres-error-terms/include/ceres-error-terms/visual-error-term-inl.h
+++ b/algorithms/ceres-error-terms/include/ceres-error-terms/visual-error-term-inl.h
@@ -183,7 +183,7 @@ bool VisualReprojectionError<CameraType, DistortionType>::Evaluate(
 
     // These Jacobians will be used in all the cases.
     J_p_C_fi_wrt_p_C_I = Eigen::Matrix3d::Identity();
-    J_p_C_fi_wrt_q_C_I = common::skew(p_C_fi);
+    J_p_C_fi_wrt_q_C_I = common::skew(R_C_I * p_I_fi);
 
     if (error_term_type_ == visual::VisualErrorType::kGlobal) {
       // The following commented expressions are evaluated in an optimized way


### PR DESCRIPTION
Fixed the analytically calculated jacobian of the cam-imu calibration quaternion being off. Explanation for the derivative based on [this](https://math.stackexchange.com/questions/2570065/derivative-of-a-rotated-vector-with-respect-to-the-quaternion) which is further based on Bloesh's [thesis](https://www.research-collection.ethz.ch/handle/20.500.11850/129873) from the section on "A Primer on the Differential Calculus of 3D Orientations".