### PR TITLE
Removed a few deprecated functions for vertices

### DIFF
--- a/map-structure/vi-map/include/vi-map/vertex.h
+++ b/map-structure/vi-map/include/vi-map/vertex.h
@@ -274,15 +274,6 @@ class Vertex : public pose_graph::Vertex {
   inline bool operator!=(const Vertex& lhs) const;
   inline bool isSameApartFromOutgoingEdges(const Vertex& lhs) const;
 
-  // Repairs the visual observation containers of this vertex after adding new
-  // keypoints to one of the frames. Resizes the observed_landmark_ids_ vector
-  // for every frame based on the number of keypoints the frames number of
-  // keypoints.
-  // Crashes hard if:
-  //    The new number of keypoints is smaller than the old one.
-  //    The keypoint vector sizes are not all equal (if set)
-  void expandVisualObservationContainersIfNecessary();
-
   size_t discardUntrackedObservations();
 
   inline int64_t getMinTimestampNanoseconds() const;
@@ -306,17 +297,6 @@ class Vertex : public pose_graph::Vertex {
   // Used for testing only.
   void addObservedLandmarkId(
       unsigned int frame_idx, const LandmarkId& landmark_id);
-
-  // Utility function to determine the new size of observed_landmark_ids_ if
-  // the number of keypoints increase.
-  // previous_new_size: new observed_landmark_ids size determined by a
-  //                    previously checked keypoint vector size
-  // current_new_size:  new observed_landmark_ids size determined by the
-  //                    current keypoint vector size
-  // old_size:          original observed_landmark_ids size
-  // returns:           the new size of observed_landmark_ids
-  int determineNewObservedLandmarkIdVectorSize(
-      int previous_new_size, int current_new_size, int old_size) const;
 
   pose_graph::VertexId id_;
   vi_map::MissionId mission_id_;

--- a/map-structure/vi-map/src/vertex.cc
+++ b/map-structure/vi-map/src/vertex.cc
@@ -687,71 +687,11 @@ int Vertex::numValidObservedLandmarkIds(unsigned int frame_idx) const {
   return landmark_ids.size();
 }
 
-int Vertex::determineNewObservedLandmarkIdVectorSize(
-    int previous_new_size, int current_new_size, int old_size) const {
-  // If the new size has been determined before by another keypoint vector, it
-  // should have be equal to the current new size.
-  CHECK_GE(current_new_size, old_size);
-  CHECK(
-      !((previous_new_size != old_size) &&
-        (previous_new_size != current_new_size)));
-  if (current_new_size > old_size) {
-    return current_new_size;
-  } else {
-    return old_size;
-  }
-}
-
 void Vertex::removeObservedLandmarkIdList(const LandmarkId& landmark_id) {
   CHECK(landmark_id.isValid());
   LandmarkId invalid_id;
   invalid_id.setInvalid();
   updateIdInObservedLandmarkIdList(landmark_id, invalid_id);
-}
-
-void Vertex::expandVisualObservationContainersIfNecessary() {
-  CHECK_EQ(n_frame_->getNumFrames(), observed_landmark_ids_.size());
-  CHECK_EQ(n_frame_->getNumFrames(), n_frame_->getNumCameras());
-
-  for (unsigned int frame_idx = 0; frame_idx < n_frame_->getNumFrames();
-       ++frame_idx) {
-    if (n_frame_->isFrameSet(frame_idx)) {
-      const aslam::VisualFrame& frame = n_frame_->getFrame(frame_idx);
-      int old_size = static_cast<int>(observed_landmark_ids_[frame_idx].size());
-      int new_size = old_size;
-      if (frame.hasDescriptors()) {
-        new_size = determineNewObservedLandmarkIdVectorSize(
-            new_size, frame.getDescriptors().cols(), old_size);
-      }
-      if (frame.hasKeypointMeasurements()) {
-        new_size = determineNewObservedLandmarkIdVectorSize(
-            new_size, frame.getKeypointMeasurements().cols(), old_size);
-      }
-      if (frame.hasKeypointMeasurementUncertainties()) {
-        new_size = determineNewObservedLandmarkIdVectorSize(
-            new_size, frame.getKeypointMeasurementUncertainties().rows(),
-            old_size);
-      }
-      if (frame.hasKeypointOrientations()) {
-        new_size = determineNewObservedLandmarkIdVectorSize(
-            new_size, frame.getKeypointOrientations().rows(), old_size);
-      }
-      if (frame.hasKeypointScales()) {
-        new_size = determineNewObservedLandmarkIdVectorSize(
-            new_size, frame.getKeypointScales().rows(), old_size);
-      }
-      if (frame.hasKeypointScores()) {
-        new_size = determineNewObservedLandmarkIdVectorSize(
-            new_size, frame.getKeypointScores().rows(), old_size);
-      }
-      if (new_size > old_size) {
-        VLOG(4) << "Resizing visual observation container from " << old_size
-                << " to " << new_size << " for VisualFrame " << frame_idx
-                << " of Vertex " << id() << " ...";
-        observed_landmark_ids_[frame_idx].resize(new_size);
-      }
-    }
-  }
 }
 
 size_t Vertex::discardUntrackedObservations() {


### PR DESCRIPTION
These two functions are unused and also poorly implemented, not serving any possible functionality or future one. More useful version will come with this PR https://github.com/ethz-asl/maplab/pull/301, but I did the removal here separately in case someone had any discussion point and to split the PR into smaller parts.