### PR TITLE
make rpg export compliant to expected file format

### DIFF
--- a/algorithms/vi-map-data-import-export/include/vi-map-data-import-export/export-vertex-data.h
+++ b/algorithms/vi-map-data-import-export/include/vi-map-data-import-export/export-vertex-data.h
@@ -14,6 +14,7 @@ int exportPosesVelocitiesAndBiasesToCsv(
     const aslam::SensorId& reference_sensor_id,
     const std::string& pose_export_file,
     const std::string& format = std::string("asl"));
+static const double kNanoSecondsToSeconds = 1e-9;
 }  // namespace data_import_export
 
 #endif  // VI_MAP_DATA_IMPORT_EXPORT_EXPORT_VERTEX_DATA_H_

--- a/algorithms/vi-map-data-import-export/src/export-vertex-data.cc
+++ b/algorithms/vi-map-data-import-export/src/export-vertex-data.cc
@@ -90,7 +90,7 @@ int exportPosesVelocitiesAndBiasesToCsv(
     const std::string kSensorFrameIdentifier =
         std::string(1, sensor_frame_identifier);
     csv_file.writeDataWithDelimiterAndNewLine(
-        kDelimiter, "timestamp_ns", "p_G_" + kSensorFrameIdentifier + "x",
+        kDelimiter, "# timestamp [s]", "p_G_" + kSensorFrameIdentifier + "x",
         "p_G_" + kSensorFrameIdentifier + "y",
         "p_G_" + kSensorFrameIdentifier + "z",
         "q_G_" + kSensorFrameIdentifier + "x",
@@ -130,8 +130,8 @@ int exportPosesVelocitiesAndBiasesToCsv(
           acc_bias[2]);
     } else if (format == "rpg") {
       csv_file.writeDataWithDelimiterAndNewLine(
-          kDelimiter, timestamp_nanoseconds, p_G_S[0], p_G_S[1], p_G_S[2],
-          q_G_S.x(), q_G_S.y(), q_G_S.z(), q_G_S.w());
+          kDelimiter, timestamp_nanoseconds * kNanoSecondsToSeconds, p_G_S[0],
+          p_G_S[1], p_G_S[2], q_G_S.x(), q_G_S.y(), q_G_S.z(), q_G_S.w());
     } else {
       LOG(ERROR) << "Invalid format " << format;
       return common::kStupidUserError;

--- a/console-plugins/vi-map-data-import-export-plugin/src/data-import-export-plugin.cc
+++ b/console-plugins/vi-map-data-import-export-plugin/src/data-import-export-plugin.cc
@@ -166,7 +166,9 @@ int DataImportExportPlugin::exportPosesVelocitiesAndBiasesToCsv(
   }
   CHECK(!mission_ids.empty());
 
-  const std::string kFilename = "vertex_poses_velocities_biases.csv";
+  const std::string kASLFileName = "vertex_poses_velocities_biases.csv";
+  const std::string kRPGFileName = "stamped_traj_estimate.txt";
+  const std::string kFilename = format == "rpg" ? kRPGFileName : kASLFileName;
   const std::string filepath =
       FLAGS_pose_export_file.empty()
           ? common::concatenateFolderAndFileName(map->getMapFolder(), kFilename)


### PR DESCRIPTION
This makes the rpg format exporter consistent with the expected dataformat (https://github.com/uzh-rpg/rpg_trajectory_evaluation)

- timestamps in seconds instead of nanoseconds
- filename consistent with what the rpg evaluation script expects (stamped_traj_estimate.txt)