### PR TITLE
Reinitialize the GFlags from the Rosparams 

### DIFF
--- a/applications/maplab-node/app/maplab-ros-node-app.cc
+++ b/applications/maplab-node/app/maplab-ros-node-app.cc
@@ -25,12 +25,15 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "maplab_node");
   ros::NodeHandle nh, nh_private("~");
 
+  // Initialize singleton and parse the current rosparams
   ros_common::parserInstance<ros_common::GflagsParser>(argv[0]);
-  ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
-      nh_private);
+  if (ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
+          nh_private)) {
+    LOG(ERROR) << "Unable to set up Gflags using rosparams! "
+               << "Using default parameters."
+  }
 
   maplab::MaplabRosNode maplab_node(nh, nh_private);
-
   if (!maplab_node.run()) {
     ROS_FATAL("Failed to start running the maplab node!");
     ros::shutdown();

--- a/applications/maplab-node/app/maplab-ros-node-app.cc
+++ b/applications/maplab-node/app/maplab-ros-node-app.cc
@@ -27,8 +27,8 @@ int main(int argc, char** argv) {
 
   // Initialize singleton and parse the current rosparams.
   ros_common::parserInstance<ros_common::GflagsParser>(argv[0]);
-  if (ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
-          nh_private)) {
+  if (!ros_common::parserInstance<ros_common::GflagsParser>()
+           .parseFromRosParams(nh_private)) {
     LOG(ERROR) << "Unable to set up Gflags using rosparams! "
                << "Using default parameters.";
   }

--- a/applications/maplab-node/app/maplab-ros-node-app.cc
+++ b/applications/maplab-node/app/maplab-ros-node-app.cc
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
   if (ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
           nh_private)) {
     LOG(ERROR) << "Unable to set up Gflags using rosparams! "
-               << "Using default parameters."
+               << "Using default parameters.";
   }
 
   maplab::MaplabRosNode maplab_node(nh, nh_private);

--- a/applications/maplab-node/app/maplab-ros-node-app.cc
+++ b/applications/maplab-node/app/maplab-ros-node-app.cc
@@ -25,8 +25,8 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "maplab_node");
   ros::NodeHandle nh, nh_private("~");
 
-  ros_common::parserInstance<GflagsParser>(argv[0]);
-  ros_common::parserInstance<GflagsParser>().parseGflagsFromRosParams(
+  ros_common::parserInstance<ros_common::GflagsParser>(argv[0]);
+  ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
       nh_private);
 
   maplab::MaplabRosNode maplab_node(nh, nh_private);

--- a/applications/maplab-node/app/maplab-ros-node-app.cc
+++ b/applications/maplab-node/app/maplab-ros-node-app.cc
@@ -25,7 +25,9 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "maplab_node");
   ros::NodeHandle nh, nh_private("~");
 
-  ros_common::parseGflagsFromRosParams(argv[0], nh_private);
+  ros_common::parserInstance<GflagsParser>(argv[0]);
+  ros_common::parserInstance<GflagsParser>().parseGflagsFromRosParams(
+      nh_private);
 
   maplab::MaplabRosNode maplab_node(nh, nh_private);
 

--- a/applications/maplab-node/app/maplab-ros-node-app.cc
+++ b/applications/maplab-node/app/maplab-ros-node-app.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "maplab_node");
   ros::NodeHandle nh, nh_private("~");
 
-  // Initialize singleton and parse the current rosparams
+  // Initialize singleton and parse the current rosparams.
   ros_common::parserInstance<ros_common::GflagsParser>(argv[0]);
   if (ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
           nh_private)) {

--- a/applications/maplab-server-node/app/maplab-server-ros-node-app.cc
+++ b/applications/maplab-server-node/app/maplab-server-ros-node-app.cc
@@ -30,7 +30,13 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "maplab_server_node");
   ros::NodeHandle nh, nh_private("~");
 
-  ros_common::parseGflagsFromRosParams(argv[0], nh_private);
+  // Initialize singleton and parse the current rosparams.
+  ros_common::parserInstance<ros_common::GflagsParser>(argv[0]);
+  if (ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
+          nh_private)) {
+    LOG(ERROR) << "Unable to set up Gflags using rosparams! "
+               << "Using default parameters.";
+  }
 
   maplab::MaplabServerRosNode maplab_server_node(nh, nh_private);
 

--- a/applications/maplab-server-node/app/maplab-server-ros-node-app.cc
+++ b/applications/maplab-server-node/app/maplab-server-ros-node-app.cc
@@ -32,8 +32,8 @@ int main(int argc, char** argv) {
 
   // Initialize singleton and parse the current rosparams.
   ros_common::parserInstance<ros_common::GflagsParser>(argv[0]);
-  if (ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
-          nh_private)) {
+  if (!ros_common::parserInstance<ros_common::GflagsParser>()
+           .parseFromRosParams(nh_private)) {
     LOG(ERROR) << "Unable to set up Gflags using rosparams! "
                << "Using default parameters.";
   }

--- a/applications/maplab-server-node/include/maplab-server-node/maplab-server-node.h
+++ b/applications/maplab-server-node/include/maplab-server-node/maplab-server-node.h
@@ -157,6 +157,8 @@ class MaplabServerNode final {
 
   bool saveRobotMissionsInfo(const backend::SaveConfig& config);
 
+  bool saveRobotTrajectories();
+
   bool loadRobotMissionsInfo();
 
   void replacePublicMap();

--- a/applications/maplab-server-node/include/maplab-server-node/maplab-server-node.h
+++ b/applications/maplab-server-node/include/maplab-server-node/maplab-server-node.h
@@ -94,6 +94,8 @@ class MaplabServerNode final {
   bool deleteAllRobotMissions(
       const std::string& robot_name, std::string* status_message);
 
+  bool clearBlacklist();
+
   // Returns an accumulation of the dense map data in global frame within a
   // radius around a center.
   bool getDenseMapInRange(

--- a/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
+++ b/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
@@ -49,6 +49,10 @@ class MaplabServerRosNode {
       std_srvs::Empty::Request& request,     // NOLINT
       std_srvs::Empty::Response& response);  // NOLINT
 
+  bool whitelistAllMissionsCallback(
+      std_srvs::Empty::Request& request,     // NOLINT
+      std_srvs::Empty::Response& response);  // NOLINT
+
   // Look up the current global frame position of a point in sensor frame.
   bool mapLookupCallback(
       maplab_msgs::BatchMapLookup::Request& requests,     // NOLINT
@@ -88,6 +92,7 @@ class MaplabServerRosNode {
 
   ros::ServiceServer save_map_srv_;
   ros::ServiceServer reinit_gflags_srv_;
+  ros::ServiceServer whitelist_missions_srv_;
   ros::ServiceServer map_lookup_srv_;
   ros::ServiceServer delete_mission_srv_;
   ros::ServiceServer delete_all_robot_missions_srv_;

--- a/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
+++ b/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
@@ -87,6 +87,7 @@ class MaplabServerRosNode {
   ros::NodeHandle nh_private_;
 
   ros::ServiceServer save_map_srv_;
+  ros::ServiceServer reinit_gflags_srv_;
   ros::ServiceServer map_lookup_srv_;
   ros::ServiceServer delete_mission_srv_;
   ros::ServiceServer delete_all_robot_missions_srv_;

--- a/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
+++ b/applications/maplab-server-node/include/maplab-server-node/maplab-server-ros-node.h
@@ -45,6 +45,10 @@ class MaplabServerRosNode {
       std_srvs::Empty::Request& request,     // NOLINT
       std_srvs::Empty::Response& response);  // NOLINT
 
+  bool reinitGflagsCallback(
+      std_srvs::Empty::Request& request,     // NOLINT
+      std_srvs::Empty::Response& response);  // NOLINT
+
   // Look up the current global frame position of a point in sensor frame.
   bool mapLookupCallback(
       maplab_msgs::BatchMapLookup::Request& requests,     // NOLINT

--- a/applications/maplab-server-node/package.xml
+++ b/applications/maplab-server-node/package.xml
@@ -40,5 +40,4 @@
 	<depend>vi_map_visualization_plugin</depend>
 	<depend>transfolder_msgs</depend>
 	<depend>sparse_graph</depend>
-	<depend>vi_map_data_import_export_plugin</depend>
 </package>

--- a/applications/maplab-server-node/package.xml
+++ b/applications/maplab-server-node/package.xml
@@ -40,4 +40,5 @@
 	<depend>vi_map_visualization_plugin</depend>
 	<depend>transfolder_msgs</depend>
 	<depend>sparse_graph</depend>
+	<depend>vi_map_data_import_export_plugin</depend>
 </package>

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -1987,10 +1987,7 @@ bool MaplabServerNode::saveRobotTrajectories() {
   // Get the path to the merged map folder.
   const std::string kFilename = "vertex_poses_velocities_biases.csv";
   const std::string filepath =
-      FLAGS_pose_export_file.empty()
-          ? common::concatenateFolderAndFileName(map->getMapFolder(), kFilename)
-          : FLAGS_pose_export_file;
-  CHECK(!filepath.empty());
+      common::concatenateFolderAndFileName(map->getMapFolder(), kFilename);
 
   // Get one reference sensor id.
   aslam::SensorId reference_sensor_id;
@@ -2004,7 +2001,8 @@ bool MaplabServerNode::saveRobotTrajectories() {
   }
   if (!reference_sensor_id.isValid()) {
     LOG(ERROR) << "[MaplabServerNode] Could not find a mission with a valid "
-                  "IMU." return false;
+                  "IMU.";
+    return false;
   }
   const std::string kFormat = "asl";
   data_import_export::exportPosesVelocitiesAndBiasesToCsv(

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -524,7 +524,7 @@ bool MaplabServerNode::saveMap() {
     bool save_map = map_manager_.saveMapToFolder(
         kMergedMapKey, FLAGS_maplab_server_merged_map_folder, config);
     save_map &= saveRobotMissionsInfo(config);
-
+    save_map &= saveRobotTrajectories();
     return save_map;
   } else {
     return false;
@@ -2007,7 +2007,7 @@ bool MaplabServerNode::saveRobotTrajectories() {
   const std::string kFormat = "asl";
   data_import_export::exportPosesVelocitiesAndBiasesToCsv(
       *map, mission_ids, reference_sensor_id, filepath, kFormat);
-  return common::kSuccess;
+  return true;
 }
 
 bool MaplabServerNode::loadRobotMissionsInfo() {

--- a/applications/maplab-server-node/src/maplab-server-ros-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-ros-node.cc
@@ -248,9 +248,8 @@ bool MaplabServerRosNode::reinitGflagsCallback(
     std_srvs::Empty::Response& /*response*/) {  // NOLINT
   LOG(INFO)
       << "[MaplabServerRosNode] Received reinitialize gflags service call...";
-  ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
-      nh_private_);
-  return true;
+  return ros_common::parserInstance<ros_common::GflagsParser>()
+      .parseFromRosParams(nh_private_);
 }
 
 bool MaplabServerRosNode::publishPoseCorrection(

--- a/applications/maplab-server-node/src/maplab-server-ros-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-ros-node.cc
@@ -18,6 +18,7 @@
 #include <maplab-common/file-system-tools.h>
 #include <maplab-common/sigint-breaker.h>
 #include <maplab-common/threading-helpers.h>
+#include <maplab-ros-common/gflags-interface.h>
 #include <maplab_msgs/MapLookupRequest.h>
 #include <maplab_msgs/MapLookupResponse.h>
 #include <maplab_msgs/VerificationCheckRequest.h>
@@ -234,6 +235,16 @@ bool MaplabServerRosNode::saveMapCallback(
     std_srvs::Empty::Response& /*response*/) {  // NOLINT
   LOG(INFO) << "[MaplabServerRosNode] Received save map service call...";
   return saveMap();
+}
+
+bool MaplabServerRosNode::reinitGflagsCallback(
+    std_srvs::Empty::Request& /*request*/,      // NOLINT
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
+  LOG(INFO)
+      << "[MaplabServerRosNode] Received reinitialize gflags service call...";
+  ros_common::parserInstance<ros_common::GflagsParser>().parseFromRosParams(
+      nh_private_);
+  return true;
 }
 
 bool MaplabServerRosNode::publishPoseCorrection(

--- a/applications/maplab-server-node/src/maplab-server-ros-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-ros-node.cc
@@ -75,6 +75,12 @@ MaplabServerRosNode::MaplabServerRosNode(
           boost::bind(&MaplabServerRosNode::saveMapCallback, this, _1, _2);
   save_map_srv_ = nh_.advertiseService("save_map", save_map_callback);
 
+  boost::function<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)>
+      reinit_gflags_callback =
+          boost::bind(&MaplabServerRosNode::reinitGflagsCallback, this, _1, _2);
+  reinit_gflags_srv_ =
+      nh_.advertiseService("reinit_gflags", reinit_gflags_callback);
+
   boost::function<bool(
       maplab_msgs::BatchMapLookup::Request&,
       maplab_msgs::BatchMapLookup::Response&)>

--- a/applications/maplab-server-node/src/maplab-server-ros-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-ros-node.cc
@@ -81,6 +81,12 @@ MaplabServerRosNode::MaplabServerRosNode(
   reinit_gflags_srv_ =
       nh_.advertiseService("reinit_gflags", reinit_gflags_callback);
 
+  boost::function<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)>
+      whitelist_missions_callback = boost::bind(
+          &MaplabServerRosNode::whitelistAllMissionsCallback, this, _1, _2);
+  whitelist_missions_srv_ =
+      nh_.advertiseService("whitelistAllMissions", whitelist_missions_callback);
+
   boost::function<bool(
       maplab_msgs::BatchMapLookup::Request&,
       maplab_msgs::BatchMapLookup::Response&)>
@@ -250,6 +256,15 @@ bool MaplabServerRosNode::reinitGflagsCallback(
       << "[MaplabServerRosNode] Received reinitialize gflags service call...";
   return ros_common::parserInstance<ros_common::GflagsParser>()
       .parseFromRosParams(nh_private_);
+}
+
+bool MaplabServerRosNode::whitelistAllMissionsCallback(
+    std_srvs::Empty::Request& /*request*/,      // NOLINT
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
+  LOG(INFO) << "[MaplabServerRosNode] Received whitelist all missions service "
+               "call...";
+
+  return maplab_server_node_->clearBlacklist();
 }
 
 bool MaplabServerRosNode::publishPoseCorrection(

--- a/common/maplab-ros-common/include/maplab-ros-common/gflags-interface.h
+++ b/common/maplab-ros-common/include/maplab-ros-common/gflags-interface.h
@@ -7,7 +7,22 @@
 
 namespace ros_common {
 
-void parseGflagsFromRosParams(
+class GflagsParser {
+ public:
+  explicit GflagsParser(const char* program_name);
+  bool parseFromRosParams(const ros::NodeHandle& nh_private) const;
+
+ private:
+  const char* program_name_;
+};
+
+template <typename T_parser>
+T_parser parserInstance(const char* program_name = nullptr) {
+  static thread_local T_parser instance(program_name);
+  return instance;
+}
+
+bool parseGflagsFromRosParams(
     const char* program_name, const ros::NodeHandle& nh_private);
 
 }  // namespace ros_common

--- a/common/maplab-ros-common/src/gflags-interface.cc
+++ b/common/maplab-ros-common/src/gflags-interface.cc
@@ -6,7 +6,7 @@
 
 namespace ros_common {
 
-void parseGflagsFromRosParams(
+bool parseGflagsFromRosParams(
     const char* program_name, const ros::NodeHandle& nh_private) {
   std::vector<google::CommandLineFlagInfo> flags;
   google::GetAllFlags(&flags);
@@ -48,10 +48,20 @@ void parseGflagsFromRosParams(
     }
   }
   const std::string ros_param_gflag_file = ss.str();
-  CHECK(google::ReadFlagsFromString(
-      ros_param_gflag_file, program_name, false /*errors_are_fatal*/));
+  if (!google::ReadFlagsFromString(
+          ros_param_gflag_file, program_name, false /*errors_are_fatal*/)) {
+    return false;
+  }
   LOG(INFO) << "\n\nThe following Gflags have been set using ROS params:\n"
             << ros_param_gflag_file << "\n";
+  return true;
+}
+
+GflagsParser::GflagsParser(const char* program_name)
+    : program_name_(program_name) {}
+
+bool GflagsParser::parseFromRosParams(const ros::NodeHandle& nh_private) const {
+  return ros_common::parseGflagsFromRosParams(program_name_, nh_private);
 }
 
 }  // namespace ros_common


### PR DESCRIPTION
## General
This PR adds a new feature to reread all configured rosparams and apply them as gflags. For each step in the processing pipeline of the server (LLC, OPT, etc.), the currently defined gflags are used to configure the algorithms. 

## Changelog
 * Minor refactor in gflags init to avoid having to set the program name all the tame
 * added an std service server to the server node

## Example

![image](https://user-images.githubusercontent.com/1336474/127656982-c9d3db61-7aec-4662-89d3-70d638704e29.png)
