### PR TITLE
MaplabNode Idle Mode

### DIFF
--- a/applications/maplab-node/include/maplab-node/maplab-ros-node.h
+++ b/applications/maplab-node/include/maplab-node/maplab-ros-node.h
@@ -48,6 +48,10 @@ class MaplabRosNode {
       std_srvs::Empty::Request& request,     // NOLINT
       std_srvs::Empty::Response& response);  // NOLINT
 
+  bool goIdleCallback(
+      std_srvs::Empty::Request& request,     // NOLINT
+      std_srvs::Empty::Response& response);  // NOLINT
+
   // Optional output.
   std::string printDeliveryQueueStatistics() const;
 
@@ -57,6 +61,7 @@ class MaplabRosNode {
   ros::NodeHandle nh_private_;
 
   ros::ServiceServer save_map_srv_;
+  ros::ServiceServer go_idle_srv_;
 
   // Settings.
   std::string map_output_folder_;

--- a/applications/maplab-node/include/maplab-node/maplab-ros-node.h
+++ b/applications/maplab-node/include/maplab-node/maplab-ros-node.h
@@ -79,6 +79,9 @@ class MaplabRosNode {
 
   // Publisher that sends the path of the map ever time it is saved.
   ros::Publisher map_update_pub_;
+
+  // Publisher that sends the amount of submaps.
+  ros::Publisher submap_counter_pub_;
 };
 
 }  // namespace maplab

--- a/applications/maplab-node/include/maplab-node/synchronizer-flow.h
+++ b/applications/maplab-node/include/maplab-node/synchronizer-flow.h
@@ -188,6 +188,9 @@ class SynchronizerFlow {
   }
 
   void shutdown() {
+    if (message_flow_ != nullptr) {
+      message_flow_->shutdown();
+    }
     synchronizer_.shutdown();
   }
 

--- a/applications/maplab-node/src/maplab-ros-node.cc
+++ b/applications/maplab-node/src/maplab-ros-node.cc
@@ -163,6 +163,11 @@ MaplabRosNode::MaplabRosNode(
       save_map_callback =
           boost::bind(&MaplabRosNode::saveMapCallback, this, _1, _2);
   save_map_srv_ = nh_.advertiseService("save_map", save_map_callback);
+
+  boost::function<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)>
+      go_idle_callback =
+          boost::bind(&MaplabRosNode::goIdleCallback, this, _1, _2);
+  go_idle_srv_ = nh_.advertiseService("go_idle", go_idle_callback);
 }
 
 bool MaplabRosNode::run() {
@@ -252,6 +257,13 @@ bool MaplabRosNode::saveMapCallback(
     std_srvs::Empty::Request& /*request*/,      // NOLINT
     std_srvs::Empty::Response& /*response*/) {  // NOLINT
   return saveMapAndContinueMapping();
+}
+
+bool MaplabRosNode::goIdleCallback(
+    std_srvs::Empty::Request& request,      // NOLINT
+    std_srvs::Empty::Response& response) {  // NOLINT
+  shutdown();
+  return true;
 }
 
 // Optional output.

--- a/applications/maplab-node/src/maplab-ros-node.cc
+++ b/applications/maplab-node/src/maplab-ros-node.cc
@@ -5,10 +5,10 @@
 #include <signal.h>
 #include <string>
 
+#include <diagnostic_msgs/KeyValue.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <ros/ros.h>
-#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 
 #include <aslam/cameras/ncamera.h>
@@ -97,7 +97,8 @@ MaplabRosNode::MaplabRosNode(
   map_update_pub_ =
       nh_.advertise<std_msgs::String>("map_update_notification", 1);
 
-  submap_counter_pub_ = nh_.advertise<std_msgs::Int32>("submap_counter", 1);
+  submap_counter_pub_ =
+      nh_.advertise<diagnostic_msgs::KeyValue>("submap_counter", 1);
 
   LOG(INFO) << "[MaplabROSNode] Initializing message flow...";
   message_flow_.reset(
@@ -229,8 +230,11 @@ bool MaplabRosNode::saveMap(
       std_msgs::String map_folder_msg;
       map_folder_msg.data = map_folder_updated;
       map_update_pub_.publish(map_folder_msg);
-      std_msgs::Int32 submap_counter_msg;
-      submap_counter_msg.data = map_counter_;
+      diagnostic_msgs::KeyValue submap_counter_msg;
+      if (nh_.getNamespace().size() > 1u) {
+        submap_counter_msg.key = nh_.getNamespace().substr(1);
+      }
+      submap_counter_msg.value = std::to_string(map_counter_);
       submap_counter_pub_.publish(submap_counter_msg);
 
       return true;

--- a/applications/maplab-node/src/maplab-ros-node.cc
+++ b/applications/maplab-node/src/maplab-ros-node.cc
@@ -262,7 +262,8 @@ bool MaplabRosNode::saveMapCallback(
 bool MaplabRosNode::goIdleCallback(
     std_srvs::Empty::Request& request,      // NOLINT
     std_srvs::Empty::Response& response) {  // NOLINT
-  shutdown();
+  message_flow_->shutdown();
+  message_flow_->waitUntilIdle();
   return true;
 }
 

--- a/applications/maplab-node/src/synchronizer.cc
+++ b/applications/maplab-node/src/synchronizer.cc
@@ -31,8 +31,12 @@ DEFINE_int64(
     "forward-propagate using the IMU.");
 DEFINE_bool(
     enable_synchronizer_statistics, false,
-    "If enable, the synchronizer will keep data about the latency and other "
+    "If enabled, the synchronizer will keep data about the latency and other "
     "key properties of the data it synchronizes.");
+DEFINE_bool(
+    enable_synchronizer_automatic_shudown, true,
+    "If enabled, the synchronizer will automatically shutdown when there has "
+    "been no new incoming data for few seconds.");
 
 namespace maplab {
 
@@ -850,10 +854,13 @@ void Synchronizer::checkIfMessagesAreIncomingWorker() {
             << "received in the last " << kMaxTimeBeforeWarningS << " seconds.";
 
         if (received_first_odometry_message_.load()) {
-          LOG(WARNING) << "[MaplabNode-Synchronizer] Either the data sources "
-                       << "has stopped publishing odometry estimates or there "
-                          "has been a data drop. Triggering shutdown!";
-          invokeEndOfDataCallbacks();
+          if (FLAGS_enable_synchronizer_automatic_shudown) {
+            LOG(WARNING)
+                << "[MaplabNode-Synchronizer] Either the data sources "
+                << "has stopped publishing odometry estimates or there "
+                   "has been a data drop. Triggering shutdown!";
+            invokeEndOfDataCallbacks();
+          }
           continue;
         } else {
           LOG(WARNING) << "[MaplabNode-Synchronizer] Check if the topic is "

--- a/applications/maplab-node/src/synchronizer.cc
+++ b/applications/maplab-node/src/synchronizer.cc
@@ -34,7 +34,7 @@ DEFINE_bool(
     "If enabled, the synchronizer will keep data about the latency and other "
     "key properties of the data it synchronizes.");
 DEFINE_bool(
-    enable_synchronizer_automatic_shudown, true,
+    enable_synchronizer_automatic_shutdown, true,
     "If enabled, the synchronizer will automatically shutdown when there has "
     "been no new incoming data for few seconds.");
 
@@ -854,7 +854,7 @@ void Synchronizer::checkIfMessagesAreIncomingWorker() {
             << "received in the last " << kMaxTimeBeforeWarningS << " seconds.";
 
         if (received_first_odometry_message_.load()) {
-          if (FLAGS_enable_synchronizer_automatic_shudown) {
+          if (FLAGS_enable_synchronizer_automatic_shutdown) {
             LOG(WARNING)
                 << "[MaplabNode-Synchronizer] Either the data sources "
                 << "has stopped publishing odometry estimates or there "


### PR DESCRIPTION
## General
This PR adds the possibility to set the `maplab_node` to an idle mode in which no new maps are built. Only the current submap data (and any other remaining) will be sent over `transfolder` to the `maplab_server_ndoe`. 

## Changelog
 * Added service call to set idle mode.
 * Added flag to control the automatic shutdown of the `maplab_node`.

## Usage
The advertised service is called: `go_idle`. Example with calling it from the console: 
> rosservice call /anymal_5/go_idle