### PR TITLE
Prefer proximity candidates over consecutives

### DIFF
--- a/console-plugins/dense-mapping-constraints-plugin/include/dense-mapping/dense-mapping-common.h
+++ b/console-plugins/dense-mapping-constraints-plugin/include/dense-mapping/dense-mapping-common.h
@@ -23,6 +23,8 @@ static std::unordered_set<backend::ResourceType, backend::ResourceTypeHash>
                             backend::ResourceType::kPointCloudXYZL,
                             backend::ResourceType::kPointCloudXYZIRT};
 
+enum class ConstraintType { consecutive, proximity, global };
+
 struct AlignmentCandidate {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -79,6 +81,7 @@ struct AlignmentCandidatePair {
       std::ostream& out, const AlignmentCandidatePair& pair);
 
   int64_t getNewestTimestamp() const;
+  ConstraintType type;
 };
 
 }  // namespace dense_mapping

--- a/console-plugins/dense-mapping-constraints-plugin/include/dense-mapping/dense-mapping-gflags.h
+++ b/console-plugins/dense-mapping-constraints-plugin/include/dense-mapping/dense-mapping-gflags.h
@@ -35,6 +35,7 @@ DECLARE_double(dm_candidate_selection_min_switch_variable_value);
 DECLARE_int32(dm_candidate_selection_max_number_of_candidates);
 DECLARE_string(dm_candidate_selection_filter_strategy);
 DECLARE_double(dm_candidate_selection_prioritize_recent_candidates);
+DECLARE_bool(dm_candidate_selection_prioritize_recent_proximity_candidates);
 
 // ALIGNMENT
 DECLARE_double(dm_candidate_alignment_max_delta_position_to_initial_guess_m);

--- a/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-gflags.cc
+++ b/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-gflags.cc
@@ -107,6 +107,10 @@ DEFINE_string(
 DEFINE_double(
     dm_candidate_selection_prioritize_recent_candidates, 0.0,
     "Defines the percentage of fixed recent candidates [0,1].");
+DEFINE_bool(
+    dm_candidate_selection_prioritize_recent_proximity_candidates, false,
+    "If true throws out consecutive candidates from the fixed recent "
+    "candidates.");
 
 // ALIGNMENTS
 DEFINE_double(

--- a/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-search.cc
+++ b/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-search.cc
@@ -419,7 +419,7 @@ bool candidatesAreSpatiallyTooFar(
 
 void createCandidatePair(
     const AlignmentCandidate& candidate_A,
-    const AlignmentCandidate& candidate_B,
+    const AlignmentCandidate& candidate_B, const ConstraintType& type,
     AlignmentCandidatePair* candidate_pair_ptr) {
   CHECK_NOTNULL(candidate_pair_ptr);
   candidate_pair_ptr->candidate_A = candidate_A;
@@ -431,11 +431,11 @@ void createCandidatePair(
 
 void addCandidatePair(
     const AlignmentCandidate& candidate_A,
-    const AlignmentCandidate& candidate_B,
+    const AlignmentCandidate& candidate_B, const ConstraintType& type,
     AlignmentCandidatePairs* candidate_pairs_ptr) {
   CHECK_NOTNULL(candidate_pairs_ptr);
   AlignmentCandidatePair pair;
-  createCandidatePair(candidate_A, candidate_B, &pair);
+  createCandidatePair(candidate_A, candidate_B, type, &pair);
   candidate_pairs_ptr->emplace(pair);
 }
 
@@ -534,7 +534,9 @@ bool searchForConsecutiveAlignmentCandidatePairs(
 
         // If we alread had a candidate B, we take the two candidates and
         // create a candidate pair and move on.
-        addCandidatePair(*candidate_A, *candidate_B, candidate_pairs_ptr);
+        addCandidatePair(
+            *candidate_A, *candidate_B, ConstraintType::consecutive,
+            candidate_pairs_ptr);
         candidate_A = candidate_B;
         candidate_B = nullptr;
         CHECK_NOTNULL(candidate_A);
@@ -680,7 +682,8 @@ bool searchForProximityBasedAlignmentCandidatePairsBetweenTwoMissions(
 
       // Create candidate pair and save it ordered by distance;
       AlignmentCandidatePair pair;
-      createCandidatePair(candidate_A, candidate_B, &pair);
+      createCandidatePair(
+          candidate_A, candidate_B, ConstraintType::proximity, &pair);
       squared_distance_to_candidate_pair_map.emplace(
           squared_distances(idx_B), std::move(pair));
     }

--- a/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-selection.cc
+++ b/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-selection.cc
@@ -131,8 +131,8 @@ static void filter_candidates_based_on_quality(
 }
 
 static void remove_consecutive_candidates(
-    std::vector<AlignmentCandidatePairs::iterator>* v,
-    const std::size_t n_reserved_candidates) {
+    const std::size_t n_reserved_candidates,
+    std::vector<AlignmentCandidatePairs::iterator>* v) {
   CHECK_NOTNULL(v);
   auto it = v->begin();
   auto it_end = v->begin() + n_reserved_candidates;
@@ -161,6 +161,9 @@ static void filter_candidates_randomly(
     const int64_t newest_rhs_ts_ns = rhs->getNewestTimestamp();
     return newest_lhs_ts_ns > newest_rhs_ts_ns;
   };
+  if (FLAGS_dm_candidate_selection_prioritize_recent_proximity_candidates) {
+    remove_consecutive_candidates(n_reserved_candidates, &v);
+  }
 
   // Sort the iterators to access the most recent ones.
   // Shuffle the remaining iterators.

--- a/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-selection.cc
+++ b/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-selection.cc
@@ -130,6 +130,19 @@ static void filter_candidates_based_on_quality(
           << " bad prior constraints.";
 }
 
+static void remove_consecutive_candidates(
+    std::vector<AlignmentCandidatePairs::iterator>* v,
+    const std::size_t n_reserved_candidates) {
+  CHECK_NOTNULL(v);
+  auto it = v->begin();
+  auto it_end = v->begin() + n_reserved_candidates;
+  for (; it != it_end; ++it) {
+    if ((*it)->type == ConstraintType::consecutive) {
+      it = std::rotate(it, it + 1, v->end());
+    }
+  }
+}
+
 static void filter_candidates_randomly(
     const std::size_t n_remaining_candidates_to_keep,
     const std::size_t n_reserved_candidates,

--- a/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-selection.cc
+++ b/console-plugins/dense-mapping-constraints-plugin/src/dense-mapping-selection.cc
@@ -130,7 +130,7 @@ static void filter_candidates_based_on_quality(
           << " bad prior constraints.";
 }
 
-static void remove_consecutive_candidates(
+static void remove_consecutive_candidates_from_priority(
     const std::size_t n_reserved_candidates,
     std::vector<AlignmentCandidatePairs::iterator>* v) {
   CHECK_NOTNULL(v);
@@ -170,7 +170,7 @@ static void filter_candidates_randomly(
   // Shuffle the remaining iterators.
   std::sort(v.begin(), v.end(), sorter);
   if (FLAGS_dm_candidate_selection_prioritize_recent_proximity_candidates) {
-    remove_consecutive_candidates(n_reserved_candidates, &v);
+    remove_consecutive_candidates_from_priority(n_reserved_candidates, &v);
   }
   std::shuffle(
       v.begin() + n_reserved_candidates, v.end(),


### PR DESCRIPTION
## General

This PR enables the removal of all consecutive alignment candidates from the reserved candidate sets. It does not erase the candidates but rather moves them to the back of the iterator vector. 
**Important:** This feature is only available when `--dm_candidate_selection_prioritize_recent_candidates` is set.

## Changelog
 * Added flag `--dm_candidate_selection_prioritize_recent_proximity_candidates` to enable this feature
 * Added consecutive filter