### PR TITLE
small fixes to compile on 20.04

### DIFF
--- a/tools/resource-importer/CMakeLists.txt
+++ b/tools/resource-importer/CMakeLists.txt
@@ -4,6 +4,8 @@ project(resource_importer)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
+set(CMAKE_CXX_STANDARD 17)
+
 cs_add_library(${PROJECT_NAME}_lib src/message-conversion.cc
                                    src/simple-rosbag-reader.cc)
 


### PR DESCRIPTION
* Specific use of cpp 17 in resource importer
* Upgrade glog_catkin to v0.5.0