### PR TITLE
Compilation Fix for Regbox

### DIFF
--- a/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
+++ b/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
@@ -75,7 +75,6 @@ class RegistrationFactory {
   RegistrationFactory() = default;
 
   static auto data() -> std::unordered_map<std::string, FuncType>& {
-
     static std::unordered_map<std::string, FuncType> singleton;
     return singleton;
   }

--- a/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
+++ b/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
@@ -73,6 +73,7 @@ class RegistrationFactory {
   RegistrationFactory() = default;
 
   static auto data() -> std::unordered_map<std::string, FuncType>& {
+
     static std::unordered_map<std::string, FuncType> singleton;
     return singleton;
   }

--- a/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
+++ b/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
@@ -1,15 +1,17 @@
 #ifndef REGISTRATION_TOOLBOX_COMMON_REGISTRATION_FACTORY_H_
 #define REGISTRATION_TOOLBOX_COMMON_REGISTRATION_FACTORY_H_
 
-#include <cstdlib>
 #include <cxxabi.h>
-#include <glog/logging.h>
+
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <typeinfo>
 #include <unordered_map>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "registration-toolbox/common/common.h"
 #include "registration-toolbox/common/supported.h"

--- a/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
+++ b/algorithms/registration-toolbox/include/registration-toolbox/common/registration-factory.h
@@ -1,17 +1,15 @@
 #ifndef REGISTRATION_TOOLBOX_COMMON_REGISTRATION_FACTORY_H_
 #define REGISTRATION_TOOLBOX_COMMON_REGISTRATION_FACTORY_H_
 
-#include <cxxabi.h>
-
 #include <cstdlib>
+#include <cxxabi.h>
+#include <glog/logging.h>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <typeinfo>
 #include <unordered_map>
 #include <utility>
-
-#include <glog/logging.h>
 
 #include "registration-toolbox/common/common.h"
 #include "registration-toolbox/common/supported.h"
@@ -74,7 +72,7 @@ class RegistrationFactory {
   using FuncType = std::shared_ptr<Base> (*)(Args...);
   RegistrationFactory() = default;
 
-  static auto& data() {
+  static auto data() -> std::unordered_map<std::string, FuncType>& {
     static std::unordered_map<std::string, FuncType> singleton;
     return singleton;
   }


### PR DESCRIPTION
# General
This PR adds a trailing return type to `registration-factory.h` as some compilers are complaining about its absence. 