### PR TITLE
Gravity Alignment of Maps

### DIFF
--- a/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
+++ b/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
@@ -7,8 +7,7 @@
 
 namespace map_anchoring {
 
-void setMissionBaseframeToKnownIfHasAbs6DoFConstraints(
-    vi_map::VIMap* map);
+void setMissionBaseframeToKnownIfHasAbs6DoFConstraints(vi_map::VIMap* map);
 
 void removeOutliersInAbsolute6DoFConstraints(vi_map::VIMap* map);
 
@@ -31,6 +30,7 @@ bool anchorMissionUsingProvidedLoopDetector(
 
 bool gravityAlignMission(
     const vi_map::MissionId& mission_id, vi_map::VIMap* map);
+bool gravityAlignAllMissions(vi_map::VIMap* map);
 }  // namespace map_anchoring
 
 #endif  // MAP_ANCHORING_MAP_ANCHORING_H_

--- a/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
+++ b/algorithms/map-anchoring/include/map-anchoring/map-anchoring.h
@@ -29,6 +29,8 @@ bool anchorMissionUsingProvidedLoopDetector(
     const loop_detector_node::LoopDetectorNode& loop_detector,
     vi_map::VIMap* map);
 
+bool gravityAlignMission(
+    const vi_map::MissionId& mission_id, vi_map::VIMap* map);
 }  // namespace map_anchoring
 
 #endif  // MAP_ANCHORING_MAP_ANCHORING_H_

--- a/algorithms/map-anchoring/package.xml
+++ b/algorithms/map-anchoring/package.xml
@@ -13,6 +13,7 @@
   <depend>gflags_catkin</depend>
   <depend>glog_catkin</depend>
   <depend>loop_closure_handler</depend>
+  <depend>landmark_triangulation</depend>
   <depend>vi_map</depend>
   <depend>visualization</depend>
 </package>

--- a/algorithms/map-anchoring/src/map-anchoring.cc
+++ b/algorithms/map-anchoring/src/map-anchoring.cc
@@ -507,4 +507,13 @@ bool gravityAlignMission(
   landmark_triangulation::retriangulateLandmarksOfMission(mission_id, map);
 }
 
+bool gravityAlignAllMissions(vi_map::VIMap* map) {
+  vi_map::MissionIdList all_missions;
+  map->getAllMissionIds(&all_missions);
+  LOG(INFO) << "gravity aligning all missions";
+  for (const vi_map::MissionId& mission_id : all_missions) {
+    LOG(INFO) << "next mission: " << mission_id;
+    gravityAlignMission(mission_id, map);
+  }
+}
 }  // namespace map_anchoring

--- a/applications/maplab-server-node/src/maplab-server-node.cc
+++ b/applications/maplab-server-node/src/maplab-server-node.cc
@@ -1268,6 +1268,10 @@ void MaplabServerNode::runSubmapProcessing(
   CHECK_EQ(missions_to_process.size(), 1u);
   const vi_map::MissionId& submap_mission_id = missions_to_process[0];
 
+  // Gravity align the submaps mission
+  ////////////////////////////////////
+  map_anchoring::gravityAlignMission(submap_mission_id, map.get());
+
   // Stationary submap fixing
   ///////////////////////////
   if (FLAGS_maplab_server_stationary_submaps_fix_with_lc_edge) {

--- a/console-plugins/map-anchoring-plugin/include/map-anchoring-plugin/anchoring-plugin.h
+++ b/console-plugins/map-anchoring-plugin/include/map-anchoring-plugin/anchoring-plugin.h
@@ -24,6 +24,8 @@ class AnchoringPlugin : public common::ConsolePluginBaseWithPlotter {
 
   int anchorMission() const;
   int anchorAllMissions() const;
+
+  int gravityAlignMission() const;
 };
 
 }  // namespace map_anchoring_plugin


### PR DESCRIPTION
Aligns a map such that the average IMU message points into positive z direction, following the coordinate system conventions of maplab for gravity alignment. This is useful if e.g. your odometry method follows a different convention.

before: 
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/5478501/202656615-94628edf-263d-4b62-9bf0-74ec860dfffd.png)

after:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/5478501/202656662-0e3a7bfc-6f66-42c6-81e0-dbbd7e666d9e.png)


