### PR TITLE
fix undefined reference to void backend::addLabelToPointCloud<resourc…

### DIFF
--- a/backend/map-resources/include/map-resources/resource-conversion-inl.h
+++ b/backend/map-resources/include/map-resources/resource-conversion-inl.h
@@ -95,7 +95,7 @@ void addScalarToPointCloud(
 
 template <typename PointCloudType>
 void addLabelToPointCloud(
-    const float scalar, const size_t index, PointCloudType* point_cloud) {
+    const uint32_t scalar, const size_t index, PointCloudType* point_cloud) {
   LOG(FATAL) << "This point cloud either does not support labels"
              << "or it is not implemented!";
 }


### PR DESCRIPTION
Fixed the below bug in compilation.
```
Errors     << maplab_console:make /media/jhuai/docker/maplab2_ws/logs/maplab_console/build.make.004.log                                                                                                    
/media/jhuai/docker/maplab2_ws/devel/lib/libdepth_integration.so: undefined reference to `void backend::addLabelToPointCloud<resources::VoxbloxColorPointCloud>(unsigned int, unsigned long, resources::VoxbloxColorPointCloud*)'
collect2: error: ld returned 1 exit status
```
Solution: float -> uint32_t

