### PR TITLE
Adding more flags to control the new FLANN search engine

### DIFF
--- a/algorithms/loopclosure/loop-closure-handler/src/loop-closure-handler.cc
+++ b/algorithms/loopclosure/loop-closure-handler/src/loop-closure-handler.cc
@@ -13,7 +13,7 @@ DEFINE_int32(
     lc_num_ransac_iters, 100,
     "Maximum number of ransac iterations for absolute pose recovery.");
 DEFINE_double(
-    lc_min_inlier_ratio, 0.0, "Minimum inlier ratio for loop closure.");
+    lc_min_inlier_ratio, 0.2, "Minimum inlier ratio for loop closure.");
 DEFINE_double(
     lc_max_delta_position_m, -1.0,
     "Maximum delta position that a loop closure can correct before it is "

--- a/algorithms/loopclosure/matching-based-loopclosure/include/matching-based-loopclosure/detector-settings.h
+++ b/algorithms/loopclosure/matching-based-loopclosure/include/matching-based-loopclosure/detector-settings.h
@@ -52,6 +52,11 @@ struct MatchingBasedEngineSettings {
   size_t min_verify_matches_num;
   float fraction_best_scores;
   int num_nearest_neighbors;
+
+  // FLANN specific settings
+  int32_t flann_num_checks;
+  double flann_eps;
+  int32_t flann_num_kdtrees;
 };
 
 }  // namespace matching_based_loopclosure

--- a/algorithms/loopclosure/matching-based-loopclosure/include/matching-based-loopclosure/flann-index-interface.h
+++ b/algorithms/loopclosure/matching-based-loopclosure/include/matching-based-loopclosure/flann-index-interface.h
@@ -99,6 +99,10 @@ class FLANNIndexInterface : public IndexInterface {
           &index_images_[batch_start], batch_end - batch_start,
           batched_index_images.back());
 
+      // Make sure the index is clear in case it has been used before
+      index_->clear();
+
+      // Add the batched images to the index
       index_->add(batched_index_images);
       initialized_ = true;
     }

--- a/algorithms/loopclosure/matching-based-loopclosure/include/matching-based-loopclosure/flann-index-interface.h
+++ b/algorithms/loopclosure/matching-based-loopclosure/include/matching-based-loopclosure/flann-index-interface.h
@@ -1,27 +1,28 @@
 #ifndef MATCHING_BASED_LOOPCLOSURE_FLANN_INDEX_INTERFACE_H_
 #define MATCHING_BASED_LOOPCLOSURE_FLANN_INDEX_INTERFACE_H_
-#include <memory>
-#include <mutex>
-#include <string>
-#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <aslam/common/timer.h>
 #include <maplab-common/binary-serialization.h>
-#include <matching-based-loopclosure/helpers.h>
-#include <matching-based-loopclosure/index-interface.h>
+#include <memory>
+#include <mutex>
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/core/version.hpp>
 #include <opencv2/features2d.hpp>
+#include <string>
+#include <vector>
+
+#include "matching-based-loopclosure/helpers.h"
+#include "matching-based-loopclosure/index-interface.h"
 
 namespace loop_closure {
 class FLANNIndexInterface : public IndexInterface {
  public:
-  FLANNIndexInterface() {
+  FLANNIndexInterface(int32_t num_checks, double eps, int32_t num_trees) {
     index_.reset(new cv::FlannBasedMatcher(
-        cv::makePtr<cv::flann::KDTreeIndexParams>(5),
-        cv::makePtr<cv::flann::SearchParams>(128)));
+        cv::makePtr<cv::flann::KDTreeIndexParams>(num_trees),
+        cv::makePtr<cv::flann::SearchParams>(num_checks, eps)));
     initialized_ = false;
     num_descriptors = 0;
   }
@@ -142,4 +143,5 @@ class FLANNIndexInterface : public IndexInterface {
   mutable std::mutex index_mutex_;
 };
 }  // namespace loop_closure
+
 #endif  // MATCHING_BASED_LOOPCLOSURE_FLANN_INDEX_INTERFACE_H_

--- a/algorithms/loopclosure/matching-based-loopclosure/src/detector-settings.cc
+++ b/algorithms/loopclosure/matching-based-loopclosure/src/detector-settings.cc
@@ -1,9 +1,9 @@
-#include "matching-based-loopclosure/detector-settings.h"
-
 #include <descriptor-projection/flags.h>
 #include <glog/logging.h>
 #include <loopclosure-common/flags.h>
 #include <loopclosure-common/types.h>
+
+#include "matching-based-loopclosure/detector-settings.h"
 
 DEFINE_string(
     lc_detector_engine,
@@ -29,8 +29,21 @@ DEFINE_int32(
     lc_num_words_for_nn_search, 10,
     "Number of nearest words to retrieve in the inverted index.");
 
-namespace matching_based_loopclosure {
+DEFINE_int32(
+    lc_flann_num_checks, 128,
+    "How many checks to perform to find the best nearest neighbor. More "
+    "checks will improve the quality but also increase the search time.");
+DEFINE_double(
+    lc_flann_eps, 0.0,
+    "Search precision for when a nearest neighbor is close enough. Increasing "
+    "this will reduce the NN search time at the cost of some lost precision as "
+    "the search will be able to exit sooner.");
+DEFINE_int32(
+    lc_flann_num_kdtrees, 4,
+    "Number of separate kd-trees to construct for the flann nearest neighbor "
+    "search. The trees will then be searched in parallel.");
 
+namespace matching_based_loopclosure {
 MatchingBasedEngineSettings::MatchingBasedEngineSettings()
     : projection_matrix_filename(FLAGS_lc_projection_matrix_filename),
       projected_quantizer_filename(FLAGS_lc_projected_quantizer_filename),
@@ -38,13 +51,19 @@ MatchingBasedEngineSettings::MatchingBasedEngineSettings()
       min_image_time_seconds(FLAGS_lc_min_image_time_seconds),
       min_verify_matches_num(FLAGS_lc_min_verify_matches_num),
       fraction_best_scores(FLAGS_lc_fraction_best_scores),
-      num_nearest_neighbors(FLAGS_lc_num_neighbors) {
+      num_nearest_neighbors(FLAGS_lc_num_neighbors),
+      flann_num_checks(FLAGS_lc_flann_num_checks),
+      flann_eps(FLAGS_lc_flann_eps),
+      flann_num_kdtrees(FLAGS_lc_flann_num_kdtrees) {
   CHECK_GT(num_closest_words_for_nn_search, 0);
   CHECK_GE(min_image_time_seconds, 0.0);
   CHECK_GE(min_verify_matches_num, 0u);
   CHECK_GT(fraction_best_scores, 0.f);
   CHECK_LT(fraction_best_scores, 1.f);
   CHECK_GE(num_nearest_neighbors, -1);
+  CHECK_GT(flann_num_checks, 0);
+  CHECK_GT(flann_eps, 0.f);
+  CHECK_GT(flann_num_kdtrees, 0);
 
   setKeyframeScoringFunctionType(FLAGS_lc_scoring_function);
   setDetectorEngineType(FLAGS_lc_detector_engine);

--- a/algorithms/loopclosure/matching-based-loopclosure/src/detector-settings.cc
+++ b/algorithms/loopclosure/matching-based-loopclosure/src/detector-settings.cc
@@ -62,7 +62,7 @@ MatchingBasedEngineSettings::MatchingBasedEngineSettings()
   CHECK_LT(fraction_best_scores, 1.f);
   CHECK_GE(num_nearest_neighbors, -1);
   CHECK_GT(flann_num_checks, 0);
-  CHECK_GT(flann_eps, 0.f);
+  CHECK_GE(flann_eps, 0.f);
   CHECK_GT(flann_num_kdtrees, 0);
 
   setKeyframeScoringFunctionType(FLAGS_lc_scoring_function);

--- a/algorithms/loopclosure/matching-based-loopclosure/src/matching-based-engine.cc
+++ b/algorithms/loopclosure/matching-based-loopclosure/src/matching-based-engine.cc
@@ -1,22 +1,21 @@
 #include <algorithm>
+#include <descriptor-projection/descriptor-projection.h>
+#include <loopclosure-common/types.h>
+#include <maplab-common/conversions.h>
+#include <maplab-common/parallel-process.h>
 #include <memory>
 #include <mutex>
+#include <nabo/nabo.h>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-
-#include <descriptor-projection/descriptor-projection.h>
-#include <loopclosure-common/types.h>
-#include <maplab-common/conversions.h>
-#include <maplab-common/parallel-process.h>
-#include <nabo/nabo.h>
 #include <vi-map/loop-constraint.h>
 
-#include "matching-based-loopclosure/flann-index-interface.h"
 #include "matching-based-loopclosure/detector-settings.h"
+#include "matching-based-loopclosure/flann-index-interface.h"
 #include "matching-based-loopclosure/helpers.h"
 #include "matching-based-loopclosure/inverted-index-interface.h"
 #include "matching-based-loopclosure/inverted-multi-index-interface.h"
@@ -319,7 +318,9 @@ void MatchingBasedLoopDetector::setDetectorEngine() {
       break;
     }
     case DetectorEngineType::kMatchingLDFLANN: {
-      index_interface_.reset(new loop_closure::FLANNIndexInterface());
+      index_interface_.reset(new loop_closure::FLANNIndexInterface(
+          settings_.flann_num_checks, settings_.flann_eps,
+          settings_.flann_num_kdtrees));
       break;
     }
     default: {


### PR DESCRIPTION
Added three new important flags to control the FLANN search engine for float descriptors:
- `flann_num_checks`: Controls the number of checks (time) spent on searching through the underlying KD-trees that are built. Especially for bigger maps larger values are necessary. This will slow down the search, but will simplify the RANSAC problem afterwards and the default parameters from BRISK will be relatively good.
- `flann_eps`: The OpenCV documentation is a bit lacking on this, but I assume the tolerance for when a descriptor is considered a nearest neighbor. Theoretically increasing this should speed up the search as it can exit earlier from a branch and not have to go all the way down.
- `lc_flann_num_kdtrees`: Number of parallel KD-trees to build and search. Around 4-6 seems to be the optimum.